### PR TITLE
fix: limit hard constraints panel to best scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `scripts/aggregate_results.py` 现在会在 `goal_progress` 配对时归一化模型名，避免当前 `vllm-hust` 数据使用裸模型名而官方 baseline artifact 使用 `org/model` 形式时无法命中同一目标基线。
 - Hard Constraints 现在只展示 `vllm-hust` 的约束状态，不再把 `vLLM 0.11.0` 目标基线也渲染成独立的 PASS / FAIL 卡片。
+- Hard Constraints 面板现在只保留当前可见范围内性能最优的 `vllm-hust` 记录，避免同页同时堆叠多条 scope 卡片。
 
 - **CI/CD pre-commit 错误修复**：
   - 修复 `data/validate_schema.py` 中未使用的 `jsonschema` 导入

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1140,6 +1140,29 @@
         ];
     }
 
+    function selectBestHardConstraintScope(scopes, sourceEntries) {
+        if (!Array.isArray(scopes) || !scopes.length) {
+            return null;
+        }
+
+        const trackedEntries = (Array.isArray(sourceEntries) ? sourceEntries : [])
+            .filter((entry) => isHardConstraintTrackedEngine(getEngine(entry)));
+        if (!trackedEntries.length) {
+            return scopes[0] || null;
+        }
+
+        const bestEntry = [...trackedEntries].sort((left, right) => {
+            const qualityCompare = compareEntryQuality(right, left);
+            if (qualityCompare !== 0) {
+                return qualityCompare;
+            }
+            return String(buildHardConstraintScopeKey(right)).localeCompare(String(buildHardConstraintScopeKey(left)));
+        })[0];
+
+        const bestScopeKey = buildHardConstraintScopeKey(bestEntry);
+        return scopes.find((scope) => scope?.scope_key === bestScopeKey) || scopes[0] || null;
+    }
+
     function renderHardConstraints(entries, comparisonView) {
         const el = document.getElementById('leaderboard-hard-constraints');
         if (!el) {
@@ -1172,15 +1195,18 @@
                 return String(left?.scope_key || '').localeCompare(String(right?.scope_key || ''));
             });
 
-        if (!filteredScopes.length) {
+        const bestScope = selectBestHardConstraintScope(filteredScopes, sourceEntries);
+        const displayedScopes = bestScope ? [bestScope] : [];
+
+        if (!displayedScopes.length) {
             el.innerHTML = `
                 <div class="hard-constraints-empty">${t('hardConstraintsNoData')}</div>
             `;
             return;
         }
 
-        const passCount = filteredScopes.filter((scope) => scope?.overall_pass).length;
-        const failCount = Math.max(filteredScopes.length - passCount, 0);
+        const passCount = displayedScopes.filter((scope) => scope?.overall_pass).length;
+        const failCount = Math.max(displayedScopes.length - passCount, 0);
 
         el.innerHTML = `
             <div class="hard-constraints-header">
@@ -1194,7 +1220,7 @@
                 </div>
             </div>
             <div class="hard-constraints-grid">
-                ${filteredScopes.map((scope) => renderHardConstraintScopeCard(scope)).join('')}
+                ${displayedScopes.map((scope) => renderHardConstraintScopeCard(scope)).join('')}
             </div>
         `;
     }


### PR DESCRIPTION
## Summary
- keep the Hard Constraints panel to a single visible vllm-hust scope card
- reuse the existing entry-quality ranking so the panel keeps the best-performing visible record
- document the UI behavior change in CHANGELOG.md

## Testing
- Verified no editor diagnostics in assets/leaderboard.js and CHANGELOG.md
- `node --check assets/leaderboard.js` could not run in this environment because `node` is not installed

## Notes
- This only changes the website rendering layer; aggregated snapshot data stays unchanged.