### PR TITLE
fix: prefer passed hard-constraint scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `scripts/aggregate_results.py` 现在会在 `goal_progress` 配对时归一化模型名，避免当前 `vllm-hust` 数据使用裸模型名而官方 baseline artifact 使用 `org/model` 形式时无法命中同一目标基线。
 - Hard Constraints 现在只展示 `vllm-hust` 的约束状态，不再把 `vLLM 0.11.0` 目标基线也渲染成独立的 PASS / FAIL 卡片。
-- Hard Constraints 面板现在只保留当前可见范围内性能最优的 `vllm-hust` 记录，避免同页同时堆叠多条 scope 卡片。
+- Hard Constraints 面板现在只保留当前可见范围内的一条 `vllm-hust` 记录：优先保留已达标项；若当前视图下没有达标项，再回退到性能最优的未达标项，避免同页同时堆叠多条 scope 卡片。
 
 - **CI/CD pre-commit 错误修复**：
   - 修复 `data/validate_schema.py` 中未使用的 `jsonschema` 导入

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1146,11 +1146,15 @@
         }
 
         const rankedScopes = [...scopes].sort((left, right) => {
-            const passCompare = Number(Boolean(right?.overall_pass)) - Number(Boolean(left?.overall_pass));
+            const passCompare = Number(Boolean(right?.overall_pass)) - Number(
+                Boolean(left?.overall_pass)
+            );
             if (passCompare !== 0) {
                 return passCompare;
             }
-            return String(left?.scope_key || '').localeCompare(String(right?.scope_key || ''));
+            return String(left?.scope_key || '').localeCompare(
+                String(right?.scope_key || '')
+            );
         });
 
         const trackedEntries = (Array.isArray(sourceEntries) ? sourceEntries : [])
@@ -1159,7 +1163,9 @@
             return rankedScopes[0] || null;
         }
 
-        const scopeByKey = new Map(scopes.map((scope) => [scope?.scope_key, scope]));
+        const scopeByKey = new Map(
+            scopes.map((scope) => [scope?.scope_key, scope])
+        );
 
         const bestCandidate = trackedEntries
             .map((entry) => {
@@ -1172,7 +1178,9 @@
             })
             .filter((candidate) => candidate.scope)
             .sort((left, right) => {
-                const passCompare = Number(Boolean(right.scope?.overall_pass)) - Number(Boolean(left.scope?.overall_pass));
+                const passCompare = Number(Boolean(right.scope?.overall_pass)) - Number(
+                    Boolean(left.scope?.overall_pass)
+                );
                 if (passCompare !== 0) {
                     return passCompare;
                 }
@@ -1182,7 +1190,9 @@
                     return qualityCompare;
                 }
 
-                return String(left.scopeKey).localeCompare(String(right.scopeKey));
+                return String(left.scopeKey).localeCompare(
+                    String(right.scopeKey)
+                );
             })[0];
 
         return bestCandidate?.scope || rankedScopes[0] || null;

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1145,22 +1145,47 @@
             return null;
         }
 
+        const rankedScopes = [...scopes].sort((left, right) => {
+            const passCompare = Number(Boolean(right?.overall_pass)) - Number(Boolean(left?.overall_pass));
+            if (passCompare !== 0) {
+                return passCompare;
+            }
+            return String(left?.scope_key || '').localeCompare(String(right?.scope_key || ''));
+        });
+
         const trackedEntries = (Array.isArray(sourceEntries) ? sourceEntries : [])
             .filter((entry) => isHardConstraintTrackedEngine(getEngine(entry)));
         if (!trackedEntries.length) {
-            return scopes[0] || null;
+            return rankedScopes[0] || null;
         }
 
-        const bestEntry = [...trackedEntries].sort((left, right) => {
-            const qualityCompare = compareEntryQuality(right, left);
-            if (qualityCompare !== 0) {
-                return qualityCompare;
-            }
-            return String(buildHardConstraintScopeKey(right)).localeCompare(String(buildHardConstraintScopeKey(left)));
-        })[0];
+        const scopeByKey = new Map(scopes.map((scope) => [scope?.scope_key, scope]));
 
-        const bestScopeKey = buildHardConstraintScopeKey(bestEntry);
-        return scopes.find((scope) => scope?.scope_key === bestScopeKey) || scopes[0] || null;
+        const bestCandidate = trackedEntries
+            .map((entry) => {
+                const scopeKey = buildHardConstraintScopeKey(entry);
+                return {
+                    entry,
+                    scopeKey,
+                    scope: scopeByKey.get(scopeKey) || null,
+                };
+            })
+            .filter((candidate) => candidate.scope)
+            .sort((left, right) => {
+                const passCompare = Number(Boolean(right.scope?.overall_pass)) - Number(Boolean(left.scope?.overall_pass));
+                if (passCompare !== 0) {
+                    return passCompare;
+                }
+
+                const qualityCompare = compareEntryQuality(right.entry, left.entry);
+                if (qualityCompare !== 0) {
+                    return qualityCompare;
+                }
+
+                return String(left.scopeKey).localeCompare(String(right.scopeKey));
+            })[0];
+
+        return bestCandidate?.scope || rankedScopes[0] || null;
     }
 
     function renderHardConstraints(entries, comparisonView) {

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -34,5 +34,6 @@ def test_hard_constraints_selection_prefers_passed_scope() -> None:
     root = Path(__file__).resolve().parents[1]
     text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
 
-    assert "Number(Boolean(right.scope?.overall_pass)) - Number(Boolean(left.scope?.overall_pass))" in text
+    assert "right.scope?.overall_pass" in text
+    assert "left.scope?.overall_pass" in text
     assert "return bestCandidate?.scope || rankedScopes[0] || null;" in text

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -28,3 +28,11 @@ def test_data_directory_has_sync_marker() -> None:
     root = Path(__file__).resolve().parents[1]
     marker = root / "data" / "last_updated.json"
     assert marker.exists(), "data sync marker is required for website freshness"
+
+
+def test_hard_constraints_selection_prefers_passed_scope() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
+
+    assert "Number(Boolean(right.scope?.overall_pass)) - Number(Boolean(left.scope?.overall_pass))" in text
+    assert "return bestCandidate?.scope || rankedScopes[0] || null;" in text


### PR DESCRIPTION
## Summary
- follow up the single-card Hard Constraints change so passed scopes win over faster failing scopes
- keep the single-card behavior, but prefer an overall-pass scope when the current view contains one
- fall back to the existing quality ranking only when no visible scope passes
- update CHANGELOG and add a lightweight regression guard in tests/test_site_structure.py

## Testing
- Verified no editor diagnostics in assets/leaderboard.js, tests/test_site_structure.py, and CHANGELOG.md
- `pytest tests/test_site_structure.py -q` could not run in this environment because `pytest` is not installed
- `python3 -m pytest tests/test_site_structure.py -q` could not run in this environment because the `pytest` module is not installed

## Context
- This is a follow-up to PR #35. The earlier change kept a single card but still ranked by raw performance, which could select a failing scope even when a passing scope was visible.