### PR TITLE
fix: decouple hard constraints card from table filters

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1198,6 +1198,19 @@
         return bestCandidate?.scope || rankedScopes[0] || null;
     }
 
+    function getHardConstraintConfigTypesForCurrentTab() {
+        if (state.currentTab === 'single-chip') {
+            return new Set(['single_gpu']);
+        }
+        if (state.currentTab === 'multi-chip') {
+            return new Set(['multi_gpu']);
+        }
+        if (state.currentTab === 'multi-node') {
+            return new Set(['multi_node']);
+        }
+        return new Set();
+    }
+
     function renderHardConstraints(entries, comparisonView) {
         const el = document.getElementById('leaderboard-hard-constraints');
         if (!el) {
@@ -1213,14 +1226,22 @@
             return;
         }
 
-        const sourceEntries = comparisonView?.visibleEntries?.length ? comparisonView.visibleEntries : entries;
+        const validConfigTypes = getHardConstraintConfigTypesForCurrentTab();
+        const sourceEntries = getDataByTab(state.currentTab).filter(
+            (entry) => isHardConstraintTrackedEngine(getEngine(entry))
+        );
         const scopeKeys = new Set(
             sourceEntries
-                .filter((entry) => isHardConstraintTrackedEngine(getEngine(entry)))
                 .map((entry) => buildHardConstraintScopeKey(entry))
         );
         const filteredScopes = scopes
             .filter((scope) => isHardConstraintTrackedEngine(scope?.latest?.engine || scope?.scope?.engine))
+            .filter((scope) => {
+                if (!validConfigTypes.size) {
+                    return true;
+                }
+                return validConfigTypes.has(String(scope?.scope?.config_type || 'unknown-config'));
+            })
             .filter((scope) => scopeKeys.has(scope.scope_key))
             .sort((left, right) => {
                 const statusOrder = Number(Boolean(left?.overall_pass)) - Number(Boolean(right?.overall_pass));

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -37,3 +37,11 @@ def test_hard_constraints_selection_prefers_passed_scope() -> None:
     assert "right.scope?.overall_pass" in text
     assert "left.scope?.overall_pass" in text
     assert "return bestCandidate?.scope || rankedScopes[0] || null;" in text
+
+
+def test_hard_constraints_selection_uses_tab_dataset_not_visible_rows() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
+
+    assert "function getHardConstraintConfigTypesForCurrentTab()" in text
+    assert "const sourceEntries = getDataByTab(state.currentTab).filter(" in text


### PR DESCRIPTION
## Summary
- decouple Hard Constraints card selection from the main table's current visible rows
- choose candidates from the current tab's full hard-constraint dataset, then prefer passed scope before quality ranking
- add a regression test to guard against re-coupling the card to table filters

## Validation
- conda run -p /root/miniconda3/envs/vllm-hust-dev python -m pytest tests/test_site_structure.py -q
- data simulation confirmed single-chip now selects the passed sharegpt-online scope when present
