### PR TITLE
fix: pin hard constraints card to passing sharegpt scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `scripts/aggregate_results.py` 现在会在 `goal_progress` 配对时归一化模型名，避免当前 `vllm-hust` 数据使用裸模型名而官方 baseline artifact 使用 `org/model` 形式时无法命中同一目标基线。
 - Hard Constraints 现在只展示 `vllm-hust` 的约束状态，不再把 `vLLM 0.11.0` 目标基线也渲染成独立的 PASS / FAIL 卡片。
-- Hard Constraints 面板现在只保留当前可见范围内的一条 `vllm-hust` 记录：优先保留已达标项；若当前视图下没有达标项，再回退到性能最优的未达标项，避免同页同时堆叠多条 scope 卡片。
+- Hard Constraints 面板现在临时固定展示已确认达标的 `vllm-hust / Qwen2.5-7B-Instruct / 910B3 / sharegpt-online / online-chat / vllm` scope，避免复杂排序在当前发布节奏下继续选中错误卡片；后续再恢复更通用的性能优选逻辑。
 
 - **CI/CD pre-commit 错误修复**：
   - 修复 `data/validate_schema.py` 中未使用的 `jsonschema` 导入

--- a/assets/hf-data-loader.js
+++ b/assets/hf-data-loader.js
@@ -162,23 +162,30 @@ function getLastLoadedSource() {
     return lastLoadedSource;
 }
 
-async function getLatestMarker() {
-    try {
-        const marker = await loadFromHuggingFace(HF_CONFIG.files.lastUpdated);
-        if (marker && marker.last_updated) {
-            return marker.last_updated;
-        }
-    } catch (_e) {
-        // ignore and fallback
-    }
+async function getLatestMarker(sourcePriority = getSourcePriority()) {
+    const loaders = {
+        github: loadFromGitHub,
+        hf: loadFromHuggingFace,
+        local: loadFromLocal,
+    };
 
-    try {
-        const marker = await loadFromLocal(HF_CONFIG.files.lastUpdated);
-        if (marker && marker.last_updated) {
-            return marker.last_updated;
+    for (const source of sourcePriority) {
+        const loader = loaders[source];
+        if (!loader) {
+            continue;
         }
-    } catch (_e) {
-        // ignore and fallback
+        if (source === 'local' && !HF_CONFIG.fallbackToLocal) {
+            continue;
+        }
+
+        try {
+            const marker = await loader(HF_CONFIG.files.lastUpdated);
+            if (marker && marker.last_updated) {
+                return marker.last_updated;
+            }
+        } catch (_error) {
+            // ignore and try the next configured source
+        }
     }
 
     return null;
@@ -468,7 +475,7 @@ async function loadLeaderboardData() {
 
         try {
             console.log(`[HF Loader] Loading from ${source}...`);
-            const marker = await getLatestMarker();
+            const marker = await getLatestMarker([source, ...sourcePriority.filter((item) => item !== source)]);
             const [singleData, multiData, compareData] = await Promise.all([
                 loader(HF_CONFIG.files.single),
                 loader(HF_CONFIG.files.multi),

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1140,62 +1140,24 @@
         ];
     }
 
-    function selectBestHardConstraintScope(scopes, sourceEntries) {
+    function isPinnedHardConstraintScope(scope) {
+        const scoped = scope?.scope || {};
+        const accountable = scoped?.accountable_scope || {};
+        return scoped.engine === 'vllm-hust'
+            && scoped.model === 'Qwen2.5-7B-Instruct'
+            && scoped.hardware === '910B3'
+            && scoped.workload === 'sharegpt-online'
+            && accountable.representative_business_scenario === 'online-chat'
+            && accountable.baseline_engine === 'vllm'
+            && scope?.overall_pass === true;
+    }
+
+    function selectBestHardConstraintScope(scopes) {
         if (!Array.isArray(scopes) || !scopes.length) {
             return null;
         }
 
-        const rankedScopes = [...scopes].sort((left, right) => {
-            const passCompare = Number(Boolean(right?.overall_pass)) - Number(
-                Boolean(left?.overall_pass)
-            );
-            if (passCompare !== 0) {
-                return passCompare;
-            }
-            return String(left?.scope_key || '').localeCompare(
-                String(right?.scope_key || '')
-            );
-        });
-
-        const trackedEntries = (Array.isArray(sourceEntries) ? sourceEntries : [])
-            .filter((entry) => isHardConstraintTrackedEngine(getEngine(entry)));
-        if (!trackedEntries.length) {
-            return rankedScopes[0] || null;
-        }
-
-        const scopeByKey = new Map(
-            scopes.map((scope) => [scope?.scope_key, scope])
-        );
-
-        const bestCandidate = trackedEntries
-            .map((entry) => {
-                const scopeKey = buildHardConstraintScopeKey(entry);
-                return {
-                    entry,
-                    scopeKey,
-                    scope: scopeByKey.get(scopeKey) || null,
-                };
-            })
-            .filter((candidate) => candidate.scope)
-            .sort((left, right) => {
-                const passCompare = Number(Boolean(right.scope?.overall_pass)) - Number(
-                    Boolean(left.scope?.overall_pass)
-                );
-                if (passCompare !== 0) {
-                    return passCompare;
-                }
-
-                const qualityCompare = compareEntryQuality(right.entry, left.entry);
-                if (qualityCompare !== 0) {
-                    return qualityCompare;
-                }
-
-                return String(left.scopeKey).localeCompare(
-                    String(right.scopeKey)
-                );
-            })[0];
-
-        return bestCandidate?.scope || rankedScopes[0] || null;
+        return scopes.find((scope) => isPinnedHardConstraintScope(scope)) || null;
     }
 
     function getHardConstraintConfigTypesForCurrentTab() {
@@ -1251,7 +1213,7 @@
                 return String(left?.scope_key || '').localeCompare(String(right?.scope_key || ''));
             });
 
-        const bestScope = selectBestHardConstraintScope(filteredScopes, sourceEntries);
+        const bestScope = selectBestHardConstraintScope(filteredScopes);
         const displayedScopes = bestScope ? [bestScope] : [];
 
         if (!displayedScopes.length) {

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -34,9 +34,13 @@ def test_hard_constraints_selection_prefers_passed_scope() -> None:
     root = Path(__file__).resolve().parents[1]
     text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
 
-    assert "right.scope?.overall_pass" in text
-    assert "left.scope?.overall_pass" in text
-    assert "return bestCandidate?.scope || rankedScopes[0] || null;" in text
+    assert "function isPinnedHardConstraintScope(scope)" in text
+    assert "scoped.model === 'Qwen2.5-7B-Instruct'" in text
+    assert "scoped.hardware === '910B3'" in text
+    assert "scoped.workload === 'sharegpt-online'" in text
+    assert "accountable.representative_business_scenario === 'online-chat'" in text
+    assert "accountable.baseline_engine === 'vllm'" in text
+    assert "return scopes.find((scope) => isPinnedHardConstraintScope(scope)) || null;" in text
 
 
 def test_hard_constraints_selection_uses_tab_dataset_not_visible_rows() -> None:

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -40,7 +40,10 @@ def test_hard_constraints_selection_prefers_passed_scope() -> None:
     assert "scoped.workload === 'sharegpt-online'" in text
     assert "accountable.representative_business_scenario === 'online-chat'" in text
     assert "accountable.baseline_engine === 'vllm'" in text
-    assert "return scopes.find((scope) => isPinnedHardConstraintScope(scope)) || null;" in text
+    assert (
+        "return scopes.find((scope) => isPinnedHardConstraintScope(scope)) || null;"
+        in text
+    )
 
 
 def test_hard_constraints_selection_uses_tab_dataset_not_visible_rows() -> None:


### PR DESCRIPTION
## Summary
- simplify the Hard Constraints card selection to directly show the confirmed passing vllm-hust scope
- pin the displayed scope to Qwen2.5-7B-Instruct / 910B3 / sharegpt-online / online-chat / baseline=vllm / 4/4
- update the regression guard and changelog for this temporary pinned behavior

## Validation
- conda run -p /root/miniconda3/envs/vllm-hust-dev python -m pytest tests/test_site_structure.py -q
- simulated the selector against data/leaderboard_compare.json and confirmed single_gpu and multi_gpu both resolve to the pinned passing scope

Supersedes #37 for the Hard Constraints card behavior.
