### PR TITLE
fix(site): guard against incomplete compare snapshots

### DIFF
--- a/assets/hf-data-loader.js
+++ b/assets/hf-data-loader.js
@@ -201,6 +201,44 @@ function normalizeEntryArray(payload) {
     return [];
 }
 
+function isCompareSnapshotUsable(compareSnapshot) {
+    if (!compareSnapshot || typeof compareSnapshot !== 'object') {
+        return true;
+    }
+
+    const groups = Array.isArray(compareSnapshot.groups) ? compareSnapshot.groups : [];
+    const goalPairs = Array.isArray(compareSnapshot?.goal_progress?.pairs)
+        ? compareSnapshot.goal_progress.pairs
+        : [];
+    const hardConstraintScopes = Array.isArray(compareSnapshot?.hard_constraints?.scopes)
+        ? compareSnapshot.hard_constraints.scopes
+        : [];
+
+    if (groups.length > 0 || goalPairs.length > 0) {
+        return true;
+    }
+
+    return hardConstraintScopes.length === 0;
+}
+
+function assertUsableLeaderboardPayload(result, source) {
+    if (isCompareSnapshotUsable(result.compare)) {
+        return;
+    }
+
+    const groups = Array.isArray(result.compare?.groups) ? result.compare.groups.length : 0;
+    const goalPairs = Array.isArray(result.compare?.goal_progress?.pairs)
+        ? result.compare.goal_progress.pairs.length
+        : 0;
+    const scopes = Array.isArray(result.compare?.hard_constraints?.scopes)
+        ? result.compare.hard_constraints.scopes.length
+        : 0;
+
+    throw new Error(
+        `Incomplete compare snapshot from ${source}: groups=${groups}, goal_pairs=${goalPairs}, hard_constraint_scopes=${scopes}`
+    );
+}
+
 function splitSingleAndMulti(entries) {
     const single = [];
     const multi = [];
@@ -485,6 +523,8 @@ async function loadLeaderboardData() {
             result.single = normalizeEntryArray(singleData);
             result.multi = normalizeEntryArray(multiData);
             result.compare = compareData && typeof compareData === 'object' ? compareData : null;
+
+            assertUsableLeaderboardPayload(result, source);
 
             writeCache(result, marker);
             setLastLoadedSource(source);

--- a/index.html
+++ b/index.html
@@ -2336,7 +2336,7 @@
     ></script>
 
     <!-- Hugging Face Data Loader (must load before leaderboard.js) -->
-    <script src="./assets/hf-data-loader.js"></script>
+    <script src="./assets/hf-data-loader.js?v=compare-source-guard-20260513"></script>
 
     <!-- Version Metadata Loader -->
     <script src="./assets/version-meta-loader.js"></script>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -77,8 +77,19 @@ def test_hard_constraints_baseline_block_is_rendered() -> None:
     assert ".hard-constraints-baseline {" in css_text
 
 
+def test_hf_loader_rejects_incomplete_compare_snapshots() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "assets" / "hf-data-loader.js").read_text(encoding="utf-8")
+
+    assert "function isCompareSnapshotUsable(compareSnapshot)" in text
+    assert "Incomplete compare snapshot from ${source}" in text
+    assert "return hardConstraintScopes.length === 0;" in text
+    assert "assertUsableLeaderboardPayload(result, source);" in text
+
+
 def test_index_cache_busts_leaderboard_script() -> None:
     root = Path(__file__).resolve().parents[1]
     text = (root / "index.html").read_text(encoding="utf-8")
 
+    assert "./assets/hf-data-loader.js?v=compare-source-guard-20260513" in text
     assert "./assets/leaderboard.js?v=hc-baseline-banner-20260513" in text


### PR DESCRIPTION
## Summary
- reject incomplete external compare snapshots that only contain hard-constraint scopes
- fall back to the next data source instead of rendering a degraded leaderboard state
- cache-bust the HF loader asset and add regression coverage

## Validation
- python3 -m pytest tests/test_site_structure.py -q
- python3 -m pre_commit run --files index.html assets/hf-data-loader.js tests/test_site_structure.py

## Root cause
The website preferred benchmark raw snapshots even when the compare payload was structurally incomplete (groups=0, goal_progress.pairs=0). This change treats that payload as unusable and falls back to the next source.