### PR TITLE
fix(site): ignore unusable cached leaderboard payloads

### DIFF
--- a/assets/hf-data-loader.js
+++ b/assets/hf-data-loader.js
@@ -45,7 +45,7 @@ const HF_CONFIG = {
     }
 };
 
-const CACHE_KEY = 'llm_engine_hf_leaderboard_cache_v1';
+const CACHE_KEY = 'llm_engine_hf_leaderboard_cache_v2';
 let lastLoadedSource = null;
 
 function getUniqueEndpoints() {
@@ -151,6 +151,14 @@ function writeCache(data, marker = null) {
         }));
     } catch (_error) {
         // ignore cache write failures
+    }
+}
+
+function clearCache() {
+    try {
+        sessionStorage.removeItem(CACHE_KEY);
+    } catch (_error) {
+        // ignore cache clear failures
     }
 }
 
@@ -469,26 +477,29 @@ async function loadOptionalJson(loader, filename) {
 async function loadLeaderboardData() {
     const cachedEnvelope = readCacheEnvelope();
     if (cachedEnvelope) {
-        if (!HF_CONFIG.validateWithMarker) {
+        if (!isCompareSnapshotUsable(cachedEnvelope.data?.compare)) {
+            clearCache();
+            console.warn('[HF Loader] Ignoring unusable session cache');
+        } else if (!HF_CONFIG.validateWithMarker) {
             setLastLoadedSource('cache');
             console.log('[HF Loader] ✅ Loaded from session cache');
             return cachedEnvelope.data;
-        }
+        } else {
+            const latestMarker = await getLatestMarker();
+            if (latestMarker && cachedEnvelope.marker && cachedEnvelope.marker === latestMarker) {
+                setLastLoadedSource('cache');
+                console.log('[HF Loader] ✅ Loaded from session cache (marker matched)');
+                return cachedEnvelope.data;
+            }
 
-        const latestMarker = await getLatestMarker();
-        if (latestMarker && cachedEnvelope.marker && cachedEnvelope.marker === latestMarker) {
-            setLastLoadedSource('cache');
-            console.log('[HF Loader] ✅ Loaded from session cache (marker matched)');
-            return cachedEnvelope.data;
-        }
+            if (!latestMarker) {
+                setLastLoadedSource('cache');
+                console.log('[HF Loader] ⚠️ Marker unavailable, fallback to TTL cache');
+                return cachedEnvelope.data;
+            }
 
-        if (!latestMarker) {
-            setLastLoadedSource('cache');
-            console.log('[HF Loader] ⚠️ Marker unavailable, fallback to TTL cache');
-            return cachedEnvelope.data;
+            console.log('[HF Loader] ♻️ Marker changed, refreshing leaderboard data');
         }
-
-        console.log('[HF Loader] ♻️ Marker changed, refreshing leaderboard data');
     }
 
     const result = { single: [], multi: [], compare: null };

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -85,6 +85,9 @@ def test_hf_loader_rejects_incomplete_compare_snapshots() -> None:
     assert "Incomplete compare snapshot from ${source}" in text
     assert "return hardConstraintScopes.length === 0;" in text
     assert "assertUsableLeaderboardPayload(result, source);" in text
+    assert "const CACHE_KEY = 'llm_engine_hf_leaderboard_cache_v2';" in text
+    assert "function clearCache()" in text
+    assert "Ignoring unusable session cache" in text
 
 
 def test_index_cache_busts_leaderboard_script() -> None:


### PR DESCRIPTION
## Summary
- ignore unusable sessionStorage leaderboard cache before honoring marker matches
- bump the session cache namespace so previously cached broken payloads stop being reused
- keep the compare snapshot structural guard covered by the website structure test

## Validation
- python3 -m pytest tests/test_site_structure.py -q
- python3 -m pre_commit run --files assets/hf-data-loader.js tests/test_site_structure.py index.html

## Root cause
Even after the compare-source fallback fix landed, browsers could keep serving the old incomplete payload from sessionStorage because the cache marker still matched the latest benchmark marker. This change invalidates that cached payload instead of trusting it.