### PR TITLE
fix: refresh contributor leaderboard source

### DIFF
--- a/data/core_contributors.json
+++ b/data/core_contributors.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-04-30",
+  "updated_at": "2026-05-14",
   "scope_repos": [
     "vllm-hust",
     "vllm-ascend-hust",
@@ -15,9 +15,9 @@
       "name": "Shuhao Zhang",
       "github_login": "ShuhaoZhangTony",
       "github_url": "https://github.com/ShuhaoZhangTony",
-      "changed_lines": 450367,
-      "added": 312721,
-      "deleted": 137646,
+      "changed_lines": 1240204,
+      "added": 1098102,
+      "deleted": 142102,
       "active_repos": 7,
       "repos": [
         "vllm-ascend-hust",
@@ -72,12 +72,27 @@
     },
     {
       "rank": 5,
+      "name": "moonandlife",
+      "github_login": "moonandlife",
+      "github_url": "https://github.com/moonandlife",
+      "changed_lines": 3468,
+      "added": 2926,
+      "deleted": 542,
+      "active_repos": 3,
+      "repos": [
+        "vllm-ascend-hust",
+        "vllm-hust",
+        "vllm-hust-dev-hub"
+      ]
+    },
+    {
+      "rank": 6,
       "name": "iliujunn",
       "github_login": "iliujunn",
       "github_url": "https://github.com/iliujunn",
-      "changed_lines": 2095,
-      "added": 1186,
-      "deleted": 909,
+      "changed_lines": 2006,
+      "added": 1102,
+      "deleted": 904,
       "active_repos": 2,
       "repos": [
         "vllm-ascend-hust",
@@ -85,7 +100,7 @@
       ]
     },
     {
-      "rank": 6,
+      "rank": 7,
       "name": "CubeLander",
       "github_login": "CubeLander",
       "github_url": "https://github.com/CubeLander",
@@ -98,7 +113,7 @@
       ]
     },
     {
-      "rank": 7,
+      "rank": 8,
       "name": "pygone",
       "github_login": "Pygone",
       "github_url": "https://github.com/Pygone",
@@ -108,20 +123,6 @@
       "active_repos": 1,
       "repos": [
         "vllm-hust-website"
-      ]
-    },
-    {
-      "rank": 8,
-      "name": "moonandlife",
-      "github_login": "moonandlife",
-      "github_url": "https://github.com/moonandlife",
-      "changed_lines": 32,
-      "added": 17,
-      "deleted": 15,
-      "active_repos": 2,
-      "repos": [
-        "vllm-hust",
-        "vllm-hust-dev-hub"
       ]
     }
   ]

--- a/index.html
+++ b/index.html
@@ -2218,6 +2218,28 @@
         renderContributorMeta(payload);
       }
 
+      const CONTRIBUTOR_DATA_SOURCES = [
+        "https://raw.githubusercontent.com/vLLM-HUST/vllm-hust-org-profile/main/profile/core_contributors.json",
+        "./data/core_contributors.json",
+      ];
+
+      async function fetchContributorPayload() {
+        let lastError = null;
+        for (const source of CONTRIBUTOR_DATA_SOURCES) {
+          try {
+            const response = await fetch(source, { cache: "no-store" });
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status} from ${source}`);
+            }
+            return await response.json();
+          } catch (error) {
+            lastError = error;
+            console.warn("Failed to load contributor data source", source, error);
+          }
+        }
+        throw lastError || new Error("No contributor data source succeeded");
+      }
+
       async function loadContributors() {
         const loading = document.getElementById("contributors-loading");
         const error = document.getElementById("contributors-error");
@@ -2225,11 +2247,7 @@
         if (!loading || !error || !content) return;
 
         try {
-          const response = await fetch("./data/core_contributors.json", { cache: "no-store" });
-          if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-          }
-          const payload = await response.json();
+          const payload = await fetchContributorPayload();
           window["vllm-hustContributorPayload"] = payload;
           renderContributors(payload);
           loading.style.display = "none";

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -85,3 +85,19 @@ def test_index_cache_busts_leaderboard_script() -> None:
 
     assert "./assets/hf-data-loader.js?v=compare-source-guard-20260513" in text
     assert "./assets/leaderboard.js?v=hc-best-scope-rank-20260514" in text
+
+
+def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "index.html").read_text(encoding="utf-8")
+
+    assert "const CONTRIBUTOR_DATA_SOURCES = [" in text
+    assert (
+        "https://raw.githubusercontent.com/vLLM-HUST/vllm-hust-org-profile/main/profile/core_contributors.json"
+        in text
+    )
+    assert '"./data/core_contributors.json"' in text
+    assert "async function fetchContributorPayload()" in text
+    assert (
+        'console.warn("Failed to load contributor data source", source, error);' in text
+    )


### PR DESCRIPTION
## Summary
- load contributor data from vllm-hust-org-profile raw JSON first
- keep local core_contributors.json as fallback data source
- refresh the website contributor snapshot and cover the new loader path with a test

## Validation
- pytest tests/test_site_structure.py -q
