### PR TITLE
Adjust leaderboard Beijing time and deploy env propagation

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1344,6 +1344,7 @@
                     <div class="overview-subtitle">${reason}</div>
                 </div>
             `;
+            el.firstElementChild?.remove();
             return;
         }
 
@@ -1387,6 +1388,7 @@
                 </div>
             </div>
         `;
+        el.firstElementChild?.remove();
 
     }
 
@@ -1795,8 +1797,36 @@
             return;
         }
 
-        const formatted = date.toISOString().replace('T', ' ').replace('.000Z', ' UTC');
+        const formatted = formatBeijingTimestamp(date);
         el.textContent = `${t('lastUpdated')}: ${formatted}`;
+    }
+
+    function formatBeijingTimestamp(date) {
+        if (typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
+            const formatter = new Intl.DateTimeFormat('en-CA', {
+                timeZone: 'Asia/Shanghai',
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+                hour12: false,
+            });
+            const parts = Object.fromEntries(
+                formatter
+                    .formatToParts(date)
+                    .filter((part) => part.type !== 'literal')
+                    .map((part) => [part.type, part.value])
+            );
+
+            if (parts.year && parts.month && parts.day && parts.hour && parts.minute && parts.second) {
+                return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}:${parts.second} UTC+8`;
+            }
+        }
+
+        const beijingDate = new Date(date.getTime() + (8 * 60 * 60 * 1000));
+        return `${beijingDate.toISOString().slice(0, 19).replace('T', ' ')} UTC+8`;
     }
 
     // Render data row

--- a/deploy/systemd/vllm-hust-website.service.template
+++ b/deploy/systemd/vllm-hust-website.service.template
@@ -6,6 +6,8 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=__REPO_DIR__
+Environment=WEBSITE_DEPLOY_HOME=__WEBSITE_DEPLOY_HOME__
+Environment=WEBSITE_SYSTEMD_ENV_FILE=__WEBSITE_SYSTEMD_ENV_FILE__
 ExecStart=/usr/bin/env bash __REPO_DIR__/scripts/run_website_systemd.sh
 Restart=always
 RestartSec=5

--- a/scripts/deploy_website_service.sh
+++ b/scripts/deploy_website_service.sh
@@ -79,7 +79,11 @@ EOF
 
 install_service_unit() {
   mkdir -p "$SYSTEMD_USER_DIR"
-  sed "s|__REPO_DIR__|$REPO_DIR|g" "$SYSTEMD_TEMPLATE" > "$(service_unit_path)"
+  sed \
+    -e "s|__REPO_DIR__|$REPO_DIR|g" \
+    -e "s|__WEBSITE_DEPLOY_HOME__|$(deploy_home)|g" \
+    -e "s|__WEBSITE_SYSTEMD_ENV_FILE__|$(systemd_env_file)|g" \
+    "$SYSTEMD_TEMPLATE" > "$(service_unit_path)"
   systemctl --user daemon-reload
   systemctl --user enable "$(service_name).service" >/dev/null
 }


### PR DESCRIPTION
## Summary
- render leaderboard last-updated in Beijing time (UTC+8)
- keep the value formatted from Asia/Shanghai instead of raw UTC
- propagate deploy-home env settings into the systemd unit so isolated deploy checks work

## Validation
- browser-checked local preview for #leaderboard-last-updated
- file-level diagnostics clean for changed files
- ran isolated ./scripts/deploy_website_service.sh ci-deploy successfully