### PR TITLE
Refine leaderboard version alignment

### DIFF
--- a/assets/leaderboard.css
+++ b/assets/leaderboard.css
@@ -914,6 +914,55 @@
     line-height: 1.1;
 }
 
+.version-main--aligned {
+    width: 100%;
+    gap: 3px;
+    --version-label-width: 9.6rem;
+}
+
+.version-aligned-row {
+    display: grid;
+    grid-template-columns: var(--version-label-width) minmax(0, 1fr);
+    align-items: baseline;
+    column-gap: 8px;
+}
+
+.version-engine-label {
+    color: #334155;
+    font-family: 'Sora', 'Inter', sans-serif;
+    font-size: 0.74rem;
+    font-weight: 700;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    white-space: nowrap;
+}
+
+.version-engine-label--hust {
+    color: #0f766e;
+}
+
+.version-engine-label--plugin {
+    color: #1d4ed8;
+}
+
+.version-engine-label--upstream {
+    color: #334155;
+}
+
+.version-engine-label--default {
+    color: #334155;
+}
+
+.version-engine-value {
+    color: #0f172a;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.76rem;
+    font-weight: 700;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    white-space: nowrap;
+}
+
 .version-provenance {
     display: inline-flex;
     align-items: center;
@@ -982,6 +1031,18 @@
     margin-top: 2px;
     color: #718096;
     font-weight: 400;
+}
+
+.version-date--aligned {
+    display: block;
+    margin-top: 2px;
+    color: #94a3b8;
+    font-family: 'Sora', 'Inter', sans-serif;
+    font-size: 0.64rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    line-height: 1.35;
+    text-align: left;
 }
 
 .version-badges {
@@ -1351,6 +1412,28 @@
         align-items: flex-start;
     }
 
+    .version-main--aligned {
+        --version-label-width: 8.3rem;
+        gap: 3px;
+    }
+
+    .version-aligned-row {
+        column-gap: 6px;
+    }
+
+    .version-engine-label {
+        font-size: 0.7rem;
+    }
+
+    .version-engine-value {
+        font-size: 0.72rem;
+    }
+
+    .version-date--aligned {
+        font-size: 0.62rem;
+        margin-top: 1px;
+    }
+
     .build-variants-table {
         font-size: 0.85em;
         min-width: 650px;
@@ -1363,6 +1446,18 @@
 }
 
 @media (max-width: 480px) {
+    .version-main--aligned {
+        --version-label-width: 7.7rem;
+    }
+
+    .version-engine-label {
+        font-size: 0.66rem;
+    }
+
+    .version-engine-value {
+        font-size: 0.68rem;
+    }
+
     .tab-button {
         padding: 10px 16px;
         font-size: 0.9em;

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -635,6 +635,158 @@
         return formatVersionText(display ? getDisplayVersion(entry) : getEngineVersion(entry));
     }
 
+    function hasVersionValue(value) {
+        const normalized = String(value || '').trim();
+        return normalized && normalized.toLowerCase() !== 'n/a' && normalized.toLowerCase() !== 'unknown';
+    }
+
+    function extractCommitFromVersion(value) {
+        const normalized = String(value || '').trim();
+        if (!normalized) {
+            return '';
+        }
+        const match = normalized.match(/(?:^|[.+-])g([0-9a-f]{7,40})(?:\.d\d{8})?$/i);
+        return match ? match[1] : '';
+    }
+
+    function normalizePackageVersion(value) {
+        const normalized = String(value || '').trim();
+        if (!hasVersionValue(normalized)) {
+            return '';
+        }
+
+        const withoutLeadingV = normalized.replace(/^v/i, '');
+        return withoutLeadingV
+            .replace(/-\d+-g[0-9a-f]{7,40}$/i, '')
+            .replace(/\+g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
+            .replace(/\.g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
+            .replace(/\.dev\d+\b/i, '')
+            .replace(/(?:[.+-])d\d{8}$/i, '');
+    }
+
+    function formatComponentVersion(version, commit, { includeCommit = true } = {}) {
+        const normalizedVersion = normalizePackageVersion(version);
+        if (!normalizedVersion) {
+            return '';
+        }
+
+        const shortCommit = getShortCommit(commit || extractCommitFromVersion(version));
+        return includeCommit && shortCommit ? `v${normalizedVersion}.${shortCommit}` : `v${normalizedVersion}`;
+    }
+
+    function getVersionLabelTone(label) {
+        if (label === 'vllm-hust') {
+            return 'hust';
+        }
+        if (label === 'vllm-ascend-hust' || label === 'vllm-ascend') {
+            return 'plugin';
+        }
+        if (label === 'vllm') {
+            return 'upstream';
+        }
+        return 'default';
+    }
+
+    function renderAlignedVersionRow(component) {
+        const tone = getVersionLabelTone(component.label);
+        return `
+            <span class="version-aligned-row">
+                <span class="version-engine-label version-engine-label--${tone}">${component.label}</span>
+                <span class="version-engine-value">${component.version}</span>
+            </span>
+        `;
+    }
+
+    function buildTableVersionComponents(entry) {
+        const metadata = entry?.metadata || {};
+        const runtime = metadata.runtime_provenance || {};
+        const versions = entry?.versions || {};
+        const githubRepository = String(metadata.github_repository || '').trim().toLowerCase();
+        const engineRepository = String(runtime?.engine?.repository || '').trim().toLowerCase();
+        const pluginRepository = String(runtime?.plugin?.repository || '').trim().toLowerCase();
+        const pluginEngine = String(runtime?.plugin?.engine || '').trim().toLowerCase();
+        const dataSource = String(metadata.data_source || '').trim().toLowerCase();
+        const engineName = getEngine(entry);
+        const engineVersion = entry?.engine_version || metadata.engine_version || '';
+        const components = [];
+
+        const isHustEngine = engineName === 'vllm-hust'
+            || engineRepository.includes('vllm-hust')
+            || githubRepository.endsWith('/vllm-hust');
+        const isHustPlugin = pluginEngine === 'vllm-ascend-hust'
+            || pluginRepository.includes('vllm-ascend-hust')
+            || githubRepository.includes('vllm-ascend-hust');
+
+        const hustVersion = hasVersionValue(versions.core)
+            ? versions.core
+            : (isHustEngine ? engineVersion : '');
+        const hustCommit = runtime?.engine?.commit
+            || (isHustEngine ? getEntryGitCommit(entry) : '')
+            || extractCommitFromVersion(versions.core)
+            || extractCommitFromVersion(engineVersion);
+
+        const hustDisplayVersion = formatComponentVersion(hustVersion, hustCommit, { includeCommit: false });
+        if (hustDisplayVersion) {
+            components.push({
+                label: 'vllm-hust',
+                version: hustDisplayVersion,
+            });
+        }
+
+        const ascendHustVersion = hasVersionValue(versions.backend)
+            ? versions.backend
+            : ((isHustPlugin || engineName === 'vllm-ascend-hust') ? engineVersion : '');
+        const ascendHustCommit = runtime?.plugin?.commit
+            || ((isHustPlugin || engineName === 'vllm-ascend-hust') ? getEntryGitCommit(entry) : '')
+            || extractCommitFromVersion(versions.backend)
+            || extractCommitFromVersion(engineVersion);
+
+        const ascendHustDisplayVersion = formatComponentVersion(ascendHustVersion, ascendHustCommit, { includeCommit: false });
+        if (ascendHustDisplayVersion) {
+            components.push({
+                label: 'vllm-ascend-hust',
+                version: ascendHustDisplayVersion,
+            });
+        }
+
+        if (components.length) {
+            return components;
+        }
+
+        const isOfficialAscendStack = engineName === 'vllm'
+            && (
+                githubRepository.includes('vllm-ascend')
+                || pluginRepository.includes('vllm-ascend')
+                || dataSource.includes('vllm-ascend')
+            );
+        const officialVersion = formatComponentVersion(engineVersion || metadata.github_ref || '', '', { includeCommit: false });
+        if (officialVersion) {
+            components.push({
+                label: engineName === 'vllm' ? 'vllm' : getEngineLabel(engineName),
+                version: officialVersion,
+            });
+            if (isOfficialAscendStack) {
+                components.push({
+                    label: 'vllm-ascend',
+                    version: officialVersion,
+                });
+            }
+        }
+
+        return components;
+    }
+
+    function formatTableVersionSummary(entry, dateLabel = '') {
+        const components = buildTableVersionComponents(entry).filter((component) => component?.label && component?.version);
+        if (!components.length) {
+            return '';
+        }
+
+        const rows = components.map((component) => renderAlignedVersionRow(component)).join('');
+        const dateLine = dateLabel ? `<small class="version-date version-date--aligned">${dateLabel}</small>` : '';
+        return `${rows}${dateLine}`;
+    }
+
     function getSameSpecPayload(entry) {
         return entry?.same_spec && typeof entry.same_spec === 'object' ? entry.same_spec : {};
     }
@@ -1834,10 +1986,12 @@
         const m = entry.metrics;
         const trends = entry.trends || {};
         const dateLabel = getEntryDateLabel(entry);
-        const dateBadge = dateLabel ? `<small class="version-date">(${dateLabel})</small>` : '';
         const displayVersion = formatEntryVersion(entry, { display: true });
         const buildCount = entry.versionVariants?.length || 1;
         const engineLabel = getEngineLabel(getEngine(entry));
+        const fallbackDate = dateLabel ? `<small class="version-date version-date--aligned">${dateLabel}</small>` : '';
+        const tableVersionSummary = formatTableVersionSummary(entry, dateLabel);
+        const versionMainText = tableVersionSummary || `${renderAlignedVersionRow({ label: engineLabel, version: displayVersion })}${fallbackDate}`;
         const provenanceSummary = renderProvenanceSummary(entry);
         const settingSummary = getSettingSummary(entry);
 
@@ -1849,7 +2003,7 @@
             <tr data-entry-id="${entry.entry_id}" class="${isSparse ? 'is-sparse' : ''}">
                 <td>
                     <div class="version-cell">
-                        ${showVersion ? `<div class="version-main">${engineLabel} ${displayVersion}${dateBadge}</div>` : ''}
+                        ${showVersion ? `<div class="version-main version-main--aligned">${versionMainText}</div>` : ''}
                         ${showVersion ? provenanceSummary : ''}
                         ${showVersion ? `<small class="version-setting-summary">${settingSummary}</small>` : ''}
                         ${showVersion && buildCount > 1 ? `<small class="version-merge-hint">${t('bestFourth')}</small>` : ''}

--- a/docs/prototypes/leaderboard-version-alignment-prototype.html
+++ b/docs/prototypes/leaderboard-version-alignment-prototype.html
@@ -1,0 +1,534 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Leaderboard Version Alignment Prototype</title>
+  <style>
+    :root {
+      --bg: #eef2f7;
+      --bg-accent: #dbe7f7;
+      --surface: rgba(255, 255, 255, 0.92);
+      --surface-strong: #ffffff;
+      --border: rgba(100, 116, 139, 0.18);
+      --border-strong: rgba(51, 65, 85, 0.22);
+      --text: #0f172a;
+      --muted: #64748b;
+      --muted-strong: #475569;
+      --label: #1e293b;
+      --accent: #0f766e;
+      --accent-soft: rgba(15, 118, 110, 0.12);
+      --accent-blue: #1d4ed8;
+      --accent-blue-soft: rgba(29, 78, 216, 0.12);
+      --shadow: 0 28px 80px -40px rgba(15, 23, 42, 0.45);
+      --engine-col: 11rem;
+      --radius: 22px;
+      --grid-radius: 16px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Sora', 'Segoe UI', sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(219, 231, 247, 0.95), transparent 30%),
+        radial-gradient(circle at top right, rgba(191, 219, 254, 0.6), transparent 28%),
+        linear-gradient(180deg, #f7fafc 0%, var(--bg) 100%);
+    }
+
+    .page {
+      max-width: 1400px;
+      margin: 0 auto;
+      padding: 48px 32px 72px;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);
+      gap: 28px;
+      align-items: stretch;
+      margin-bottom: 28px;
+    }
+
+    .hero-card,
+    .notes-card,
+    .table-card {
+      background: var(--surface);
+      backdrop-filter: blur(14px);
+      border: 1px solid rgba(255, 255, 255, 0.65);
+      box-shadow: var(--shadow);
+      border-radius: var(--radius);
+    }
+
+    .hero-card {
+      padding: 28px 30px 30px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-card::after {
+      content: '';
+      position: absolute;
+      inset: auto -60px -70px auto;
+      width: 220px;
+      height: 220px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(15, 118, 110, 0.12), transparent 65%);
+      pointer-events: none;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.05);
+      color: var(--muted-strong);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 18px;
+    }
+
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.05;
+      letter-spacing: -0.04em;
+    }
+
+    .lead {
+      margin: 0;
+      max-width: 62ch;
+      color: var(--muted-strong);
+      font-size: 15px;
+      line-height: 1.65;
+    }
+
+    .notes-card {
+      padding: 24px 24px 26px;
+    }
+
+    .notes-card h2 {
+      margin: 0 0 14px;
+      font-size: 16px;
+      letter-spacing: -0.02em;
+    }
+
+    .notes-card ul {
+      margin: 0;
+      padding-left: 18px;
+      color: var(--muted-strong);
+      font-size: 14px;
+      line-height: 1.65;
+    }
+
+    .table-card {
+      padding: 18px 18px 20px;
+    }
+
+    .table-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 10px 8px 16px;
+    }
+
+    .table-title {
+      margin: 0;
+      font-size: 18px;
+      letter-spacing: -0.02em;
+    }
+
+    .table-subtitle {
+      margin: 4px 0 0;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .table-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.78);
+      border: 1px solid var(--border);
+      color: var(--muted-strong);
+      font-size: 12px;
+      font-weight: 700;
+      white-space: nowrap;
+    }
+
+    .grid-shell {
+      overflow-x: auto;
+      border-radius: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(248, 250, 252, 0.92) 100%);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+      min-width: 1180px;
+    }
+
+    thead th {
+      padding: 16px 16px 15px;
+      text-align: left;
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      background: rgba(248, 250, 252, 0.88);
+    }
+
+    tbody td {
+      padding: 16px;
+      border-bottom: 1px solid rgba(226, 232, 240, 0.95);
+      vertical-align: top;
+      background: rgba(255, 255, 255, 0.94);
+    }
+
+    tbody tr:hover td {
+      background: rgba(248, 250, 252, 0.98);
+    }
+
+    tbody tr.is-focus td {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 250, 249, 0.96) 100%);
+    }
+
+    .version-cell {
+      min-width: 320px;
+    }
+
+    .version-block {
+      display: grid;
+      gap: 6px;
+      padding: 14px 16px;
+      border-radius: var(--grid-radius);
+      border: 1px solid var(--border);
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(244, 247, 250, 0.96) 100%);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+    }
+
+    .version-row {
+      display: grid;
+      grid-template-columns: var(--engine-col) minmax(0, 1fr);
+      align-items: baseline;
+      column-gap: 14px;
+    }
+
+    .version-engine {
+      color: var(--label);
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 1.35;
+      letter-spacing: -0.01em;
+      white-space: nowrap;
+    }
+
+    .version-engine.engine-hust {
+      color: var(--accent);
+    }
+
+    .version-engine.engine-plugin {
+      color: var(--accent-blue);
+    }
+
+    .version-value {
+      min-width: 0;
+      color: var(--text);
+      font-family: 'Fira Code', 'SFMono-Regular', monospace;
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 1.35;
+      letter-spacing: -0.01em;
+      white-space: nowrap;
+    }
+
+    .version-date {
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      text-align: left;
+      padding-top: 2px;
+    }
+
+    .version-footnote {
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .metric {
+      font-family: 'Fira Code', 'SFMono-Regular', monospace;
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--text);
+      line-height: 1.4;
+    }
+
+    .metric-subtle {
+      color: var(--muted);
+      font-size: 12px;
+      margin-top: 4px;
+    }
+
+    .config {
+      color: var(--text);
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 1.45;
+    }
+
+    .config small {
+      display: block;
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .btn-details {
+      width: 100%;
+      min-width: 92px;
+      padding: 10px 12px;
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      border-radius: 999px;
+      background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      cursor: default;
+      box-shadow: 0 8px 16px -16px rgba(15, 23, 42, 0.45);
+    }
+
+    .btn-details.secondary {
+      color: var(--muted-strong);
+      background: rgba(248, 250, 252, 0.9);
+    }
+
+    .legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 18px;
+      padding: 0 6px;
+    }
+
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--muted-strong);
+      font-size: 12px;
+      font-weight: 600;
+    }
+
+    .legend-swatch {
+      width: 11px;
+      height: 11px;
+      border-radius: 999px;
+    }
+
+    .legend-swatch.engine {
+      background: var(--accent);
+    }
+
+    .legend-swatch.plugin {
+      background: var(--accent-blue);
+    }
+
+    .legend-swatch.date {
+      background: var(--muted);
+    }
+
+    @media (max-width: 980px) {
+      .page {
+        padding: 28px 18px 48px;
+      }
+
+      .hero {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 640px) {
+      :root {
+        --engine-col: 8.6rem;
+      }
+
+      .version-engine,
+      .version-value {
+        font-size: 12px;
+      }
+
+      .version-date {
+        font-size: 11px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="hero">
+      <article class="hero-card">
+        <div class="eyebrow">Prototype / VS Code Preview</div>
+        <h1>Leaderboard Version Alignment Prototype</h1>
+        <p class="lead">
+          这个原型只演示版本区视觉结构，不改生产页面。目标是让引擎名左对齐、版本号列对齐，并把第三行日期做成整体左对齐，避免继续挤压右侧操作按钮。
+        </p>
+      </article>
+      <aside class="notes-card">
+        <h2>Visual Rules</h2>
+        <ul>
+          <li>`vllm-hust` 与 `vllm-ascend-hust` 分两行展示，左列标签对齐，右列版本号对齐。</li>
+          <li>如果存在 `postN` 则保留；如果没有 `postN`，直接忽略，不展示 `devNNN`。</li>
+          <li>`vllm` 与 `vllm-ascend` 采用同一套两列规则，保证榜单扫读一致。</li>
+          <li>第三行日期保持左对齐，不再缩进到版本列下方。</li>
+        </ul>
+      </aside>
+    </section>
+
+    <section class="table-card">
+      <div class="table-head">
+        <div>
+          <h2 class="table-title">Mock Leaderboard Row Layout</h2>
+          <p class="table-subtitle">A high-fidelity table prototype tuned for the existing action button column.</p>
+        </div>
+        <div class="table-pill">Engine labels aligned, version values aligned, date left aligned</div>
+      </div>
+
+      <div class="grid-shell">
+        <table>
+          <thead>
+            <tr>
+              <th>Engine / Version</th>
+              <th>Workload</th>
+              <th>Hardware</th>
+              <th>TTFT</th>
+              <th>TBT</th>
+              <th>Tokens/s</th>
+              <th>Error Rate</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="is-focus">
+              <td class="version-cell">
+                <div class="version-block">
+                  <div class="version-row">
+                    <span class="version-engine engine-hust">vllm-hust</span>
+                    <span class="version-value">v0.17.2.post1</span>
+                  </div>
+                  <div class="version-row">
+                    <span class="version-engine engine-plugin">vllm-ascend-hust</span>
+                    <span class="version-value">v0.17.2.post1</span>
+                  </div>
+                  <div class="version-date">2026-05-12</div>
+                </div>
+                <div class="version-footnote">Same release version across engine and plugin, with a stable two-column rhythm.</div>
+              </td>
+              <td>
+                <div class="config">Random Online</div>
+                <small class="metric-subtle">Qwen2.5-14B-Instruct</small>
+              </td>
+              <td>
+                <div class="config">1 x 910B3</div>
+                <small>(single node)</small>
+              </td>
+              <td><div class="metric">271.1 ms</div></td>
+              <td><div class="metric">72.8 ms</div></td>
+              <td><div class="metric">227.1</div></td>
+              <td><div class="metric">0.0%</div></td>
+              <td><button class="btn-details">Details</button></td>
+            </tr>
+
+            <tr>
+              <td class="version-cell">
+                <div class="version-block">
+                  <div class="version-row">
+                    <span class="version-engine engine-hust">vllm-hust</span>
+                    <span class="version-value">v0.20.1rc1</span>
+                  </div>
+                  <div class="version-row">
+                    <span class="version-engine engine-plugin">vllm-ascend-hust</span>
+                    <span class="version-value">v0.1</span>
+                  </div>
+                  <div class="version-date">2026-05-06</div>
+                </div>
+                <div class="version-footnote">No `postN` present, so the display omits any `devNNN` suffix.</div>
+              </td>
+              <td>
+                <div class="config">Sonnet Throughput</div>
+                <small class="metric-subtle">Qwen2.5-14B-Instruct</small>
+              </td>
+              <td>
+                <div class="config">2 x 910B3</div>
+                <small>(single node)</small>
+              </td>
+              <td><div class="metric">0.0 ms</div></td>
+              <td><div class="metric">-</div></td>
+              <td><div class="metric">2341.4</div></td>
+              <td><div class="metric">0.0%</div></td>
+              <td><button class="btn-details secondary">Details</button></td>
+            </tr>
+
+            <tr>
+              <td class="version-cell">
+                <div class="version-block">
+                  <div class="version-row">
+                    <span class="version-engine">vllm</span>
+                    <span class="version-value">v0.11.0</span>
+                  </div>
+                  <div class="version-row">
+                    <span class="version-engine engine-plugin">vllm-ascend</span>
+                    <span class="version-value">v0.11.0</span>
+                  </div>
+                  <div class="version-date">2026-05-08</div>
+                </div>
+                <div class="version-footnote">The upstream baseline follows the same alignment rule for consistency.</div>
+              </td>
+              <td>
+                <div class="config">Random Online</div>
+                <small class="metric-subtle">Qwen2.5-14B-Instruct</small>
+              </td>
+              <td>
+                <div class="config">1 x 910B3</div>
+                <small>(single node)</small>
+              </td>
+              <td><div class="metric">271.1 ms</div></td>
+              <td><div class="metric">72.8 ms</div></td>
+              <td><div class="metric">227.1</div></td>
+              <td><div class="metric">0.0%</div></td>
+              <td><button class="btn-details secondary">Details</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="legend">
+        <div class="legend-item"><span class="legend-swatch engine"></span> Engine labels remain in the left column.</div>
+        <div class="legend-item"><span class="legend-swatch plugin"></span> Plugin labels reuse the same alignment grid.</div>
+        <div class="legend-item"><span class="legend-swatch date"></span> The date is intentionally left aligned on the third line.</div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/prototypes/leaderboard-version-alignment-prototype.svg
+++ b/docs/prototypes/leaderboard-version-alignment-prototype.svg
@@ -1,0 +1,146 @@
+<svg width="1440" height="1040" viewBox="0 0 1440 1040" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="180" y1="60" x2="1240" y2="980" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F8FBFF"/>
+      <stop offset="1" stop-color="#EBF1F7"/>
+    </linearGradient>
+    <linearGradient id="cardGradient" x1="260" y1="160" x2="1170" y2="910" gradientUnits="userSpaceOnUse">
+      <stop stop-color="white" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.92"/>
+    </linearGradient>
+    <linearGradient id="versionPanel" x1="176" y1="356" x2="446" y2="574" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#F6F9FC"/>
+    </linearGradient>
+    <filter id="cardShadow" x="98" y="80" width="1244" height="900" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="28"/>
+      <feGaussianBlur stdDeviation="36"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0588235 0 0 0 0 0.0901961 0 0 0 0 0.164706 0 0 0 0.14 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+    <style>
+      .title { fill: #0F172A; font: 700 42px 'Sora', 'Segoe UI', sans-serif; letter-spacing: -1.6px; }
+      .eyebrow { fill: #475569; font: 700 12px 'Sora', 'Segoe UI', sans-serif; letter-spacing: 1.8px; text-transform: uppercase; }
+      .body { fill: #475569; font: 500 16px 'Sora', 'Segoe UI', sans-serif; }
+      .cardTitle { fill: #0F172A; font: 700 18px 'Sora', 'Segoe UI', sans-serif; letter-spacing: -0.3px; }
+      .rule { fill: #334155; font: 500 14px 'Sora', 'Segoe UI', sans-serif; }
+      .head { fill: #64748B; font: 700 11px 'Sora', 'Segoe UI', sans-serif; letter-spacing: 1.4px; text-transform: uppercase; }
+      .value { fill: #0F172A; font: 700 13px 'SFMono-Regular', Consolas, monospace; }
+      .metric { fill: #0F172A; font: 700 13px 'SFMono-Regular', Consolas, monospace; }
+      .muted { fill: #64748B; font: 600 12px 'Sora', 'Segoe UI', sans-serif; }
+      .engine { fill: #1E293B; font: 700 13px 'Sora', 'Segoe UI', sans-serif; }
+      .engineHust { fill: #0F766E; font: 700 13px 'Sora', 'Segoe UI', sans-serif; }
+      .enginePlugin { fill: #1D4ED8; font: 700 13px 'Sora', 'Segoe UI', sans-serif; }
+      .small { fill: #64748B; font: 500 12px 'Sora', 'Segoe UI', sans-serif; }
+      .pill { fill: #334155; font: 700 12px 'Sora', 'Segoe UI', sans-serif; }
+      .button { fill: #0F172A; font: 700 12px 'Sora', 'Segoe UI', sans-serif; letter-spacing: 0.8px; text-transform: uppercase; }
+      .caption { fill: #64748B; font: 500 12px 'Sora', 'Segoe UI', sans-serif; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="1040" fill="url(#bgGradient)"/>
+  <circle cx="180" cy="120" r="220" fill="#DBE7F7" fill-opacity="0.65"/>
+  <circle cx="1320" cy="180" r="190" fill="#BFDBFE" fill-opacity="0.45"/>
+
+  <g filter="url(#cardShadow)">
+    <rect x="130" y="112" width="1180" height="826" rx="28" fill="url(#cardGradient)"/>
+  </g>
+
+  <rect x="162" y="144" width="192" height="34" rx="17" fill="#F1F5F9"/>
+  <text x="186" y="165" class="eyebrow">Prototype / VS Code Preview</text>
+
+  <text x="162" y="228" class="title">Leaderboard Version Alignment Prototype</text>
+  <text x="162" y="268" class="body">A static high-fidelity mock that keeps engine labels left aligned, version values aligned,</text>
+  <text x="162" y="292" class="body">and the third-line date left aligned while preserving room for the action button column.</text>
+
+  <rect x="912" y="150" width="366" height="164" rx="22" fill="#FFFFFF" fill-opacity="0.86" stroke="#E2E8F0"/>
+  <text x="940" y="186" class="cardTitle">Visual Rules</text>
+  <text x="940" y="220" class="rule">1. Two aligned rows for vllm-hust and vllm-ascend-hust.</text>
+  <text x="940" y="246" class="rule">2. Keep postN when present, ignore devNNN when absent.</text>
+  <text x="940" y="272" class="rule">3. Apply the same rule to vllm and vllm-ascend.</text>
+  <text x="940" y="298" class="rule">4. Date is intentionally left aligned on line three.</text>
+
+  <text x="162" y="350" class="cardTitle">Mock Leaderboard Rows</text>
+  <text x="162" y="376" class="small">This prototype preserves the existing right-side action button footprint.</text>
+
+  <rect x="162" y="400" width="1116" height="472" rx="22" fill="#FFFFFF" fill-opacity="0.94" stroke="#E2E8F0"/>
+
+  <rect x="162" y="400" width="1116" height="58" rx="22" fill="#F8FAFC"/>
+  <text x="188" y="435" class="head">Engine / Version</text>
+  <text x="564" y="435" class="head">Workload</text>
+  <text x="716" y="435" class="head">Hardware</text>
+  <text x="832" y="435" class="head">TTFT</text>
+  <text x="916" y="435" class="head">TBT</text>
+  <text x="992" y="435" class="head">Tokens/s</text>
+  <text x="1096" y="435" class="head">Error Rate</text>
+  <text x="1190" y="435" class="head">Action</text>
+
+  <line x1="162" y1="458" x2="1278" y2="458" stroke="#E2E8F0"/>
+  <line x1="162" y1="598" x2="1278" y2="598" stroke="#E2E8F0"/>
+  <line x1="162" y1="736" x2="1278" y2="736" stroke="#E2E8F0"/>
+
+  <rect x="178" y="482" width="328" height="90" rx="18" fill="url(#versionPanel)" stroke="#E2E8F0"/>
+  <text x="196" y="516" class="engineHust">vllm-hust</text>
+  <text x="362" y="516" class="value">v0.17.2.post1</text>
+  <text x="196" y="542" class="enginePlugin">vllm-ascend-hust</text>
+  <text x="362" y="542" class="value">v0.17.2.post1</text>
+  <text x="196" y="566" class="small">2026-05-12</text>
+
+  <text x="564" y="516" class="engine">Random Online</text>
+  <text x="564" y="540" class="small">Qwen2.5-14B-Instruct</text>
+  <text x="716" y="516" class="engine">1 x 910B3</text>
+  <text x="716" y="540" class="small">single node</text>
+  <text x="832" y="516" class="metric">271.1 ms</text>
+  <text x="916" y="516" class="metric">72.8 ms</text>
+  <text x="992" y="516" class="metric">227.1</text>
+  <text x="1096" y="516" class="metric">0.0%</text>
+  <rect x="1174" y="494" width="82" height="34" rx="17" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="1197" y="515" class="button">Details</text>
+
+  <rect x="178" y="620" width="328" height="90" rx="18" fill="url(#versionPanel)" stroke="#E2E8F0"/>
+  <text x="196" y="654" class="engineHust">vllm-hust</text>
+  <text x="362" y="654" class="value">v0.20.1rc1</text>
+  <text x="196" y="680" class="enginePlugin">vllm-ascend-hust</text>
+  <text x="362" y="680" class="value">v0.1</text>
+  <text x="196" y="704" class="small">2026-05-06</text>
+
+  <text x="564" y="654" class="engine">Sonnet Throughput</text>
+  <text x="564" y="678" class="small">Qwen2.5-14B-Instruct</text>
+  <text x="716" y="654" class="engine">2 x 910B3</text>
+  <text x="716" y="678" class="small">single node</text>
+  <text x="832" y="654" class="metric">0.0 ms</text>
+  <text x="916" y="654" class="metric">-</text>
+  <text x="992" y="654" class="metric">2341.4</text>
+  <text x="1096" y="654" class="metric">0.0%</text>
+  <rect x="1174" y="632" width="82" height="34" rx="17" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="1197" y="653" class="button">Details</text>
+
+  <rect x="178" y="758" width="328" height="90" rx="18" fill="url(#versionPanel)" stroke="#E2E8F0"/>
+  <text x="196" y="792" class="engine">vllm</text>
+  <text x="362" y="792" class="value">v0.11.0</text>
+  <text x="196" y="818" class="enginePlugin">vllm-ascend</text>
+  <text x="362" y="818" class="value">v0.11.0</text>
+  <text x="196" y="842" class="small">2026-05-08</text>
+
+  <text x="564" y="792" class="engine">Random Online</text>
+  <text x="564" y="816" class="small">Qwen2.5-14B-Instruct</text>
+  <text x="716" y="792" class="engine">1 x 910B3</text>
+  <text x="716" y="816" class="small">single node</text>
+  <text x="832" y="792" class="metric">271.1 ms</text>
+  <text x="916" y="792" class="metric">72.8 ms</text>
+  <text x="992" y="792" class="metric">227.1</text>
+  <text x="1096" y="792" class="metric">0.0%</text>
+  <rect x="1174" y="770" width="82" height="34" rx="17" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="1197" y="791" class="button">Details</text>
+
+  <rect x="162" y="900" width="1116" height="1" fill="#E2E8F0" fill-opacity="0.4"/>
+  <circle cx="182" cy="932" r="6" fill="#0F766E"/>
+  <text x="196" y="937" class="caption">Engine labels stay in a fixed left column.</text>
+  <circle cx="468" cy="932" r="6" fill="#1D4ED8"/>
+  <text x="482" y="937" class="caption">Plugin labels reuse the same alignment grid.</text>
+  <circle cx="806" cy="932" r="6" fill="#64748B"/>
+  <text x="820" y="937" class="caption">The third-line date is intentionally left aligned.</text>
+</svg>

--- a/docs/prototypes/leaderboard-version-public-showcase-prototype.svg
+++ b/docs/prototypes/leaderboard-version-public-showcase-prototype.svg
@@ -1,0 +1,155 @@
+<svg width="1440" height="1080" viewBox="0 0 1440 1080" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="pageBg" x1="108" y1="60" x2="1310" y2="1020" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FCF9F2"/>
+      <stop offset="0.42" stop-color="#F7F4EC"/>
+      <stop offset="1" stop-color="#EEF3F8"/>
+    </linearGradient>
+    <linearGradient id="heroGlow" x1="214" y1="118" x2="924" y2="468" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF4D6"/>
+      <stop offset="1" stop-color="#F7FAFF" stop-opacity="0.4"/>
+    </linearGradient>
+    <linearGradient id="panelFill" x1="142" y1="152" x2="1284" y2="948" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9FBFD" stop-opacity="0.94"/>
+    </linearGradient>
+    <linearGradient id="rowHighlight" x1="176" y1="482" x2="556" y2="642" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFDF7"/>
+      <stop offset="1" stop-color="#F7FAFC"/>
+    </linearGradient>
+    <linearGradient id="badgeGold" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#FBBF24"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+    <filter id="panelShadow" x="80" y="96" width="1280" height="908" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="30"/>
+      <feGaussianBlur stdDeviation="32"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0588235 0 0 0 0 0.0901961 0 0 0 0 0.164706 0 0 0 0.13 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+    <style>
+      .eyebrow { fill:#7C5E10; font:700 12px 'Sora','Segoe UI',sans-serif; letter-spacing:1.8px; text-transform:uppercase; }
+      .title { fill:#0F172A; font:700 44px 'Sora','Segoe UI',sans-serif; letter-spacing:-1.8px; }
+      .subtitle { fill:#475569; font:500 16px 'Sora','Segoe UI',sans-serif; }
+      .sectionTitle { fill:#0F172A; font:700 20px 'Sora','Segoe UI',sans-serif; letter-spacing:-0.4px; }
+      .sectionBody { fill:#475569; font:500 14px 'Sora','Segoe UI',sans-serif; }
+      .smallCaps { fill:#64748B; font:700 11px 'Sora','Segoe UI',sans-serif; letter-spacing:1.4px; text-transform:uppercase; }
+      .metric { fill:#0F172A; font:700 13px 'SFMono-Regular',Consolas,monospace; }
+      .engine { fill:#334155; font:700 13px 'Sora','Segoe UI',sans-serif; }
+      .engineHust { fill:#0F766E; font:700 13px 'Sora','Segoe UI',sans-serif; }
+      .enginePlugin { fill:#1D4ED8; font:700 13px 'Sora','Segoe UI',sans-serif; }
+      .version { fill:#0F172A; font:700 13px 'SFMono-Regular',Consolas,monospace; }
+      .meta { fill:#64748B; font:600 12px 'Sora','Segoe UI',sans-serif; }
+      .note { fill:#64748B; font:500 12px 'Sora','Segoe UI',sans-serif; }
+      .button { fill:#0F172A; font:700 12px 'Sora','Segoe UI',sans-serif; letter-spacing:0.7px; text-transform:uppercase; }
+      .pill { fill:#92400E; font:700 12px 'Sora','Segoe UI',sans-serif; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="1080" fill="url(#pageBg)"/>
+  <circle cx="124" cy="118" r="196" fill="#FDE68A" fill-opacity="0.26"/>
+  <circle cx="1302" cy="124" r="164" fill="#BFDBFE" fill-opacity="0.18"/>
+  <circle cx="1286" cy="944" r="220" fill="#CFFAFE" fill-opacity="0.16"/>
+
+  <g filter="url(#panelShadow)">
+    <rect x="112" y="128" width="1216" height="844" rx="32" fill="url(#panelFill)"/>
+  </g>
+
+  <rect x="148" y="164" width="808" height="184" rx="28" fill="url(#heroGlow)" stroke="#FDE7A8"/>
+  <rect x="172" y="188" width="200" height="34" rx="17" fill="#FFF7E3" stroke="#FDE68A"/>
+  <text x="198" y="209" class="eyebrow">Public Leaderboard Direction</text>
+  <text x="172" y="266" class="title">Version Cell Showcase</text>
+  <text x="172" y="304" class="subtitle">A public-ranking visual prototype that feels editorial and polished, while still keeping</text>
+  <text x="172" y="328" class="subtitle">engine labels aligned, version values aligned, and the third-line date left aligned.</text>
+
+  <rect x="986" y="164" width="306" height="184" rx="28" fill="#FFFFFF" fill-opacity="0.84" stroke="#E2E8F0"/>
+  <rect x="1012" y="190" width="112" height="30" rx="15" fill="#FEF3C7"/>
+  <text x="1042" y="209" class="pill">Design Notes</text>
+  <text x="1012" y="248" class="sectionBody">• Same layout rule for HUST and upstream rows</text>
+  <text x="1012" y="276" class="sectionBody">• No devNNN if postN is absent</text>
+  <text x="1012" y="304" class="sectionBody">• Date remains on its own left-aligned line</text>
+
+  <text x="148" y="392" class="sectionTitle">Leaderboard Mock</text>
+  <text x="148" y="420" class="sectionBody">This variant uses a cleaner, more public-facing presentation without touching production code.</text>
+
+  <rect x="148" y="446" width="1144" height="448" rx="24" fill="#FFFFFF" fill-opacity="0.93" stroke="#E2E8F0"/>
+  <rect x="148" y="446" width="1144" height="60" rx="24" fill="#F8FAFC"/>
+
+  <text x="176" y="483" class="smallCaps">Engine / Version</text>
+  <text x="568" y="483" class="smallCaps">Workload</text>
+  <text x="720" y="483" class="smallCaps">Hardware</text>
+  <text x="840" y="483" class="smallCaps">TTFT</text>
+  <text x="924" y="483" class="smallCaps">TBT</text>
+  <text x="1000" y="483" class="smallCaps">Tokens/s</text>
+  <text x="1106" y="483" class="smallCaps">Error Rate</text>
+  <text x="1198" y="483" class="smallCaps">Action</text>
+
+  <line x1="148" y1="506" x2="1292" y2="506" stroke="#E2E8F0"/>
+  <line x1="148" y1="636" x2="1292" y2="636" stroke="#E2E8F0"/>
+  <line x1="148" y1="766" x2="1292" y2="766" stroke="#E2E8F0"/>
+
+  <rect x="164" y="526" width="330" height="88" rx="20" fill="url(#rowHighlight)" stroke="#F3E8B3"/>
+  <rect x="182" y="542" width="74" height="22" rx="11" fill="url(#badgeGold)"/>
+  <text x="201" y="557" fill="#FFFFFF" font-family="Sora, Segoe UI, sans-serif" font-size="11" font-weight="700">Featured</text>
+  <text x="182" y="578" class="engineHust">vllm-hust</text>
+  <text x="346" y="578" class="version">v0.17.2.post1</text>
+  <text x="182" y="604" class="enginePlugin">vllm-ascend-hust</text>
+  <text x="346" y="604" class="version">v0.17.2.post1</text>
+  <text x="182" y="626" class="meta">2026-05-12</text>
+
+  <text x="568" y="570" class="engine">Random Online</text>
+  <text x="568" y="594" class="note">Qwen2.5-14B-Instruct</text>
+  <text x="720" y="570" class="engine">1 x 910B3</text>
+  <text x="720" y="594" class="note">single node</text>
+  <text x="840" y="570" class="metric">271.1 ms</text>
+  <text x="924" y="570" class="metric">72.8 ms</text>
+  <text x="1000" y="570" class="metric">227.1</text>
+  <text x="1106" y="570" class="metric">0.0%</text>
+  <rect x="1184" y="550" width="84" height="34" rx="17" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="1208" y="571" class="button">Details</text>
+
+  <rect x="164" y="656" width="330" height="88" rx="20" fill="#FFFFFF" stroke="#E2E8F0"/>
+  <text x="182" y="688" class="engineHust">vllm-hust</text>
+  <text x="346" y="688" class="version">v0.20.1rc1</text>
+  <text x="182" y="714" class="enginePlugin">vllm-ascend-hust</text>
+  <text x="346" y="714" class="version">v0.1</text>
+  <text x="182" y="736" class="meta">2026-05-06</text>
+
+  <text x="568" y="680" class="engine">Sonnet Throughput</text>
+  <text x="568" y="704" class="note">Qwen2.5-14B-Instruct</text>
+  <text x="720" y="680" class="engine">2 x 910B3</text>
+  <text x="720" y="704" class="note">single node</text>
+  <text x="840" y="680" class="metric">0.0 ms</text>
+  <text x="924" y="680" class="metric">-</text>
+  <text x="1000" y="680" class="metric">2341.4</text>
+  <text x="1106" y="680" class="metric">0.0%</text>
+  <rect x="1184" y="660" width="84" height="34" rx="17" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="1208" y="681" class="button">Details</text>
+
+  <rect x="164" y="786" width="330" height="88" rx="20" fill="#FFFFFF" stroke="#E2E8F0"/>
+  <text x="182" y="818" class="engine">vllm</text>
+  <text x="346" y="818" class="version">v0.11.0</text>
+  <text x="182" y="844" class="enginePlugin">vllm-ascend</text>
+  <text x="346" y="844" class="version">v0.11.0</text>
+  <text x="182" y="866" class="meta">2026-05-08</text>
+
+  <text x="568" y="810" class="engine">Official Baseline</text>
+  <text x="568" y="834" class="note">Qwen2.5-14B-Instruct</text>
+  <text x="720" y="810" class="engine">1 x 910B3</text>
+  <text x="720" y="834" class="note">single node</text>
+  <text x="840" y="810" class="metric">271.1 ms</text>
+  <text x="924" y="810" class="metric">72.8 ms</text>
+  <text x="1000" y="810" class="metric">227.1</text>
+  <text x="1106" y="810" class="metric">0.0%</text>
+  <rect x="1184" y="790" width="84" height="34" rx="17" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="1208" y="811" class="button">Details</text>
+
+  <rect x="148" y="920" width="1144" height="1" fill="#E2E8F0" fill-opacity="0.5"/>
+  <circle cx="172" cy="950" r="5" fill="#0F766E"/>
+  <text x="186" y="955" class="sectionBody">A subtle featured treatment fits a public leaderboard without changing the alignment rule.</text>
+  <circle cx="726" cy="950" r="5" fill="#64748B"/>
+  <text x="740" y="955" class="sectionBody">Date stays on line three and aligns with the left edge of the version block.</text>
+</svg>


### PR DESCRIPTION
## Summary
- align leaderboard row version labels and values into a two-column version-main layout
- keep the third-line date left aligned with reduced visual weight
- add HTML/SVG prototypes under docs/prototypes for design review

## Validation
- git diff --check
- local browser preview against ?dataSource=local
- verified version-main DOM for the first and fifth leaderboard rows while keeping the action button visible