### PR TITLE
Fix leaderboard version derivation

### DIFF
--- a/assets/leaderboard.css
+++ b/assets/leaderboard.css
@@ -969,10 +969,12 @@
 }
 
 .version-provenance {
-    display: inline-flex;
+    display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 6px;
+    max-width: 100%;
+    min-width: 0;
     color: #475569;
     font-size: 0.72rem;
     font-weight: 600;
@@ -998,6 +1000,17 @@
 .provenance-commit {
     color: #1e3a8a;
     font-family: 'Fira Code', monospace;
+}
+
+.version-setting-summary,
+.version-merge-hint,
+.provenance-user,
+.provenance-source,
+.provenance-repo,
+.provenance-commit {
+    max-width: 100%;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .provenance-link,
@@ -1353,6 +1366,25 @@
 }
 
 /* Responsive Design */
+@media (max-width: 1100px) {
+    .leaderboard-table th:first-child,
+    .leaderboard-table td:first-child {
+        position: static;
+        left: auto;
+    }
+
+    .version-main--aligned {
+        --version-label-width: 100%;
+        gap: 5px;
+    }
+
+    .version-aligned-row {
+        grid-template-columns: minmax(0, 1fr);
+        column-gap: 0;
+        row-gap: 1px;
+    }
+}
+
 @media (max-width: 768px) {
     .leaderboard-section {
         padding: 24px 16px;
@@ -1417,15 +1449,6 @@
         align-items: flex-start;
     }
 
-    .version-main--aligned {
-        --version-label-width: 8.3rem;
-        gap: 3px;
-    }
-
-    .version-aligned-row {
-        column-gap: 6px;
-    }
-
     .version-engine-label {
         font-size: 0.7rem;
     }
@@ -1451,16 +1474,6 @@
 }
 
 @media (max-width: 480px) {
-    .version-main--aligned {
-        --version-label-width: 100%;
-        gap: 5px;
-    }
-
-    .version-aligned-row {
-        grid-template-columns: minmax(0, 1fr);
-        row-gap: 1px;
-    }
-
     .version-engine-label {
         font-size: 0.66rem;
     }

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -640,6 +640,20 @@
         return normalized && normalized.toLowerCase() !== 'n/a' && normalized.toLowerCase() !== 'unknown';
     }
 
+    function isCommitLikeValue(value) {
+        const normalized = String(value || '').trim();
+        if (!normalized) {
+            return false;
+        }
+
+        const candidate = normalized.replace(/^[vg]/i, '');
+        return /[a-f]/i.test(candidate) && /^[0-9a-f]{7,40}$/i.test(candidate);
+    }
+
+    function hasRenderablePackageVersion(value) {
+        return hasVersionValue(value) && !isCommitLikeValue(value);
+    }
+
     function extractCommitFromVersion(value) {
         const normalized = String(value || '').trim();
         if (!normalized) {
@@ -651,17 +665,19 @@
 
     function normalizePackageVersion(value) {
         const normalized = String(value || '').trim();
-        if (!hasVersionValue(normalized)) {
+        if (!hasRenderablePackageVersion(normalized)) {
             return '';
         }
 
         const withoutLeadingV = normalized.replace(/^v/i, '');
-        return withoutLeadingV
+        const cleaned = withoutLeadingV
             .replace(/-\d+-g[0-9a-f]{7,40}$/i, '')
             .replace(/\+g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
             .replace(/\.g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
             .replace(/\.dev\d+\b/i, '')
             .replace(/(?:[.+-])d\d{8}$/i, '');
+
+        return isCommitLikeValue(cleaned) ? '' : cleaned;
     }
 
     function formatComponentVersion(version, commit, { includeCommit = true } = {}) {
@@ -710,18 +726,21 @@
         const engineVersion = entry?.engine_version || metadata.engine_version || '';
         const components = [];
 
-        const isHustEngine = engineName === 'vllm-hust'
-            || engineRepository.includes('vllm-hust')
+        const hasHustEngineRepository = engineRepository.includes('vllm-hust')
             || githubRepository.endsWith('/vllm-hust');
-        const isHustPlugin = pluginEngine === 'vllm-ascend-hust'
+        const hasHustPluginRepository = pluginEngine === 'vllm-ascend-hust'
             || pluginRepository.includes('vllm-ascend-hust')
             || githubRepository.includes('vllm-ascend-hust');
+        const canUseEngineVersionForHust = hasHustEngineRepository
+            || (engineName === 'vllm-hust' && !hasHustPluginRepository);
+        const canUseEngineVersionForPlugin = engineName === 'vllm-ascend-hust'
+            || (hasHustPluginRepository && !hasHustEngineRepository);
 
-        const hustVersion = hasVersionValue(versions.core)
+        const hustVersion = hasRenderablePackageVersion(versions.core)
             ? versions.core
-            : (isHustEngine ? engineVersion : '');
+            : (canUseEngineVersionForHust ? engineVersion : '');
         const hustCommit = runtime?.engine?.commit
-            || (isHustEngine ? getEntryGitCommit(entry) : '')
+            || (canUseEngineVersionForHust ? getEntryGitCommit(entry) : '')
             || extractCommitFromVersion(versions.core)
             || extractCommitFromVersion(engineVersion);
 
@@ -733,11 +752,11 @@
             });
         }
 
-        const ascendHustVersion = hasVersionValue(versions.backend)
+        const ascendHustVersion = hasRenderablePackageVersion(versions.backend)
             ? versions.backend
-            : ((isHustPlugin || engineName === 'vllm-ascend-hust') ? engineVersion : '');
+            : (canUseEngineVersionForPlugin ? engineVersion : '');
         const ascendHustCommit = runtime?.plugin?.commit
-            || ((isHustPlugin || engineName === 'vllm-ascend-hust') ? getEntryGitCommit(entry) : '')
+            || (canUseEngineVersionForPlugin ? getEntryGitCommit(entry) : '')
             || extractCommitFromVersion(versions.backend)
             || extractCommitFromVersion(engineVersion);
 

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     />
 
     <!-- Leaderboard Styles -->
-    <link rel="stylesheet" href="./assets/leaderboard.css" />
+    <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-responsive-20260523-2" />
 
     <style>
       * {
@@ -2363,6 +2363,6 @@
     <script src="./assets/workstation-embed.js"></script>
 
     <!-- Leaderboard Script -->
-    <script src="./assets/leaderboard.js?v=hc-best-scope-rank-20260514"></script>
+    <script src="./assets/leaderboard.js?v=leaderboard-responsive-20260523-2"></script>
   </body>
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -83,8 +84,9 @@ def test_index_cache_busts_leaderboard_script() -> None:
     root = Path(__file__).resolve().parents[1]
     text = (root / "index.html").read_text(encoding="utf-8")
 
-    assert "./assets/hf-data-loader.js?v=compare-source-guard-20260513" in text
-    assert "./assets/leaderboard.js?v=hc-best-scope-rank-20260514" in text
+    assert re.search(r'\.\/assets\/hf-data-loader\.js\?v=[^"\']+', text)
+    assert re.search(r'\.\/assets\/leaderboard\.js\?v=[^"\']+', text)
+    assert re.search(r'\.\/assets\/leaderboard\.css\?v=[^"\']+', text)
 
 
 def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> None:


### PR DESCRIPTION
## Summary
- fix incorrect leaderboard version derivation for entries whose available metadata only represents plugin-side versions
- ignore commit-like strings when rendering table version values to avoid bogus values such as va<sha>
- broaden the narrow-window fallback and bump leaderboard asset cache versions so the updated JS/CSS are actually loaded

## Validation
- verified a fresh local preview page loads leaderboard.js and leaderboard.css with the new cache-busting version
- confirmed row 13 now renders as `vllm-ascend-hust v0.1 2026-04-17` instead of incorrectly showing both labels
- confirmed the page no longer contains `va<sha>` version values
- git diff --check and file error checks for index.html / assets/leaderboard.js / assets/leaderboard.css