### PR TITLE
fix: restore github snapshot versions

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -600,6 +600,11 @@
         return shortCommit ? `g${shortCommit}` : '';
     }
 
+    function sanitizeDisplayEngineVersion(version, gitCommit = '') {
+        const sanitized = sanitizeEngineVersion(version, gitCommit);
+        return hasRenderablePackageVersion(sanitized) ? sanitized : '';
+    }
+
     function formatVersionText(version) {
         const normalized = String(version || '').trim();
         if (!normalized || normalized.toLowerCase() === 'unknown') {
@@ -627,8 +632,13 @@
     }
 
     function getDisplayVersion(entry) {
-        const explicit = sanitizeEngineVersion(entry?.displayVersion || '', getEntryGitCommit(entry));
-        return normalizeDisplayVersion(explicit || getEngineVersion(entry));
+        const gitCommit = getEntryGitCommit(entry);
+        const explicit = sanitizeDisplayEngineVersion(entry?.displayVersion || '', gitCommit);
+        const engineVersion = sanitizeDisplayEngineVersion(
+            entry?.engine_version || entry?.metadata?.engine_version || '',
+            gitCommit
+        );
+        return normalizeDisplayVersion(explicit || engineVersion);
     }
 
     function formatEntryVersion(entry, { display = false } = {}) {
@@ -638,6 +648,20 @@
     function hasVersionValue(value) {
         const normalized = String(value || '').trim();
         return normalized && normalized.toLowerCase() !== 'n/a' && normalized.toLowerCase() !== 'unknown';
+    }
+
+    function isCommitLikeValue(value) {
+        const normalized = String(value || '').trim();
+        if (!normalized) {
+            return false;
+        }
+
+        const candidate = normalized.replace(/^[vg]/i, '');
+        return /[a-f]/i.test(candidate) && /^[0-9a-f]{7,40}$/i.test(candidate);
+    }
+
+    function hasRenderablePackageVersion(value) {
+        return hasVersionValue(value) && !isCommitLikeValue(value);
     }
 
     function extractCommitFromVersion(value) {
@@ -651,17 +675,19 @@
 
     function normalizePackageVersion(value) {
         const normalized = String(value || '').trim();
-        if (!hasVersionValue(normalized)) {
+        if (!hasRenderablePackageVersion(normalized)) {
             return '';
         }
 
         const withoutLeadingV = normalized.replace(/^v/i, '');
-        return withoutLeadingV
+        const cleaned = withoutLeadingV
             .replace(/-\d+-g[0-9a-f]{7,40}$/i, '')
             .replace(/\+g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
             .replace(/\.g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
             .replace(/\.dev\d+\b/i, '')
             .replace(/(?:[.+-])d\d{8}$/i, '');
+
+        return isCommitLikeValue(cleaned) ? '' : cleaned;
     }
 
     function formatComponentVersion(version, commit, { includeCommit = true } = {}) {
@@ -672,6 +698,82 @@
 
         const shortCommit = getShortCommit(commit || extractCommitFromVersion(version));
         return includeCommit && shortCommit ? `v${normalizedVersion}.${shortCommit}` : `v${normalizedVersion}`;
+    }
+
+    function getRepositoryName(repository) {
+        const normalized = String(repository || '').trim().toLowerCase();
+        if (!normalized) {
+            return '';
+        }
+        const parts = normalized.split('/').filter(Boolean);
+        return parts.length ? parts[parts.length - 1] : normalized;
+    }
+
+    function isHustCoreRepository(repository) {
+        return getRepositoryName(repository) === 'vllm-hust';
+    }
+
+    function isHustPluginRepository(repository) {
+        return getRepositoryName(repository) === 'vllm-ascend-hust';
+    }
+
+    function compactGitRef(ref) {
+        const normalized = String(ref || '').trim();
+        if (!normalized) {
+            return '';
+        }
+        return normalized.length > 24
+            ? `${normalized.slice(0, 14)}...${normalized.slice(-8)}`
+            : normalized;
+    }
+
+    function formatRecordedRevision(ref, commit) {
+        const refLabel = compactGitRef(ref);
+        const shortCommit = getShortCommit(commit);
+        if (refLabel && shortCommit) {
+            return `${refLabel}@${shortCommit}`;
+        }
+        if (shortCommit) {
+            return `commit:${shortCommit}`;
+        }
+        return refLabel;
+    }
+
+    const HISTORICAL_SAME_SPEC_VERSION_OVERRIDES = {
+        'vllm-ascend-hust-ci-same-spec|vllm-hust|vllm-hust': '0.17.2.post1',
+        'vllm-ascend-hust-ci-same-spec|vllm-ascend-hust|vllm-ascend-hust': '0.1',
+        'vllm-hust-ci-same-spec|vllm-hust|vllm-hust': '0.17.2.post1',
+        'vllm-hust-ci-same-spec|vllm-ascend-hust|vllm-ascend-hust': '0.18.0.post1',
+    };
+
+    function getHistoricalSameSpecVersionOverride(dataSource, label, repository) {
+        const key = [
+            String(dataSource || '').trim().toLowerCase(),
+            String(label || '').trim().toLowerCase(),
+            getRepositoryName(repository),
+        ].join('|');
+        return HISTORICAL_SAME_SPEC_VERSION_OVERRIDES[key] || '';
+    }
+
+    function resolveVersionDisplayValue(version, commit, ref, { overrideVersion = '', fallbackToRecordedRevision = false, missingValue = '' } = {}) {
+        const semanticVersion = formatComponentVersion(version, commit, { includeCommit: false });
+        if (semanticVersion) {
+            return semanticVersion;
+        }
+
+        const semanticOverride = formatComponentVersion(overrideVersion, '', { includeCommit: false });
+        if (semanticOverride) {
+            return semanticOverride;
+        }
+
+        if (fallbackToRecordedRevision) {
+            const recordedRevision = formatRecordedRevision(ref, commit);
+            if (recordedRevision) {
+                return recordedRevision;
+            }
+        }
+
+        return missingValue;
     }
 
     function getVersionLabelTone(label) {
@@ -697,55 +799,125 @@
         `;
     }
 
+    function buildComponentVisibilityKey(label, version, commit, ref) {
+        return [
+            String(label || '').trim(),
+            String(version || '').trim(),
+            String(ref || '').trim(),
+            getShortCommit(commit),
+        ].join('|');
+    }
+
     function buildTableVersionComponents(entry) {
         const metadata = entry?.metadata || {};
         const runtime = metadata.runtime_provenance || {};
         const versions = entry?.versions || {};
-        const githubRepository = String(metadata.github_repository || '').trim().toLowerCase();
-        const engineRepository = String(runtime?.engine?.repository || '').trim().toLowerCase();
-        const pluginRepository = String(runtime?.plugin?.repository || '').trim().toLowerCase();
-        const pluginEngine = String(runtime?.plugin?.engine || '').trim().toLowerCase();
+        const githubRepository = String(metadata.github_repository || '').trim();
+        const sharedSource = {
+            repository: githubRepository,
+            ref: String(metadata.github_ref || '').trim(),
+            commit: String(metadata.git_commit || '').trim(),
+        };
+        const engineSource = {
+            repository: String(runtime?.engine?.repository || '').trim()
+                || (isHustCoreRepository(sharedSource.repository) ? sharedSource.repository : ''),
+            ref: String(runtime?.engine?.ref || '').trim()
+                || (isHustCoreRepository(sharedSource.repository) ? sharedSource.ref : ''),
+            commit: String(runtime?.engine?.commit || '').trim()
+                || (isHustCoreRepository(sharedSource.repository) ? sharedSource.commit : ''),
+        };
+        const pluginSource = {
+            engine: String(runtime?.plugin?.engine || '').trim()
+                || (isHustPluginRepository(sharedSource.repository) ? 'vllm-ascend-hust' : ''),
+            repository: String(runtime?.plugin?.repository || '').trim()
+                || (isHustPluginRepository(sharedSource.repository) ? sharedSource.repository : ''),
+            ref: String(runtime?.plugin?.ref || '').trim()
+                || (isHustPluginRepository(sharedSource.repository) ? sharedSource.ref : ''),
+            commit: String(runtime?.plugin?.commit || '').trim()
+                || (isHustPluginRepository(sharedSource.repository) ? sharedSource.commit : ''),
+        };
+        const engineRepository = engineSource.repository.toLowerCase();
+        const pluginRepository = pluginSource.repository.toLowerCase();
+        const pluginEngine = pluginSource.engine.toLowerCase();
         const dataSource = String(metadata.data_source || '').trim().toLowerCase();
         const engineName = getEngine(entry);
         const engineVersion = entry?.engine_version || metadata.engine_version || '';
         const components = [];
 
-        const isHustEngine = engineName === 'vllm-hust'
-            || engineRepository.includes('vllm-hust')
-            || githubRepository.endsWith('/vllm-hust');
-        const isHustPlugin = pluginEngine === 'vllm-ascend-hust'
+        const hasHustEngineRepository = engineRepository.includes('vllm-hust')
+            || githubRepository.toLowerCase().endsWith('/vllm-hust');
+        const hasHustPluginRepository = pluginEngine === 'vllm-ascend-hust'
             || pluginRepository.includes('vllm-ascend-hust')
-            || githubRepository.includes('vllm-ascend-hust');
+            || githubRepository.toLowerCase().includes('vllm-ascend-hust');
+        const canUseEngineVersionForHust = hasHustEngineRepository
+            || (engineName === 'vllm-hust' && !hasHustPluginRepository);
+        const canUseEngineVersionForPlugin = engineName === 'vllm-ascend-hust'
+            || (hasHustPluginRepository && !hasHustEngineRepository);
 
-        const hustVersion = hasVersionValue(versions.core)
+        const hustVersion = hasRenderablePackageVersion(versions.core)
             ? versions.core
-            : (isHustEngine ? engineVersion : '');
-        const hustCommit = runtime?.engine?.commit
-            || (isHustEngine ? getEntryGitCommit(entry) : '')
+            : (canUseEngineVersionForHust ? engineVersion : '');
+        const hustCommit = engineSource.commit
             || extractCommitFromVersion(versions.core)
             || extractCommitFromVersion(engineVersion);
 
-        const hustDisplayVersion = formatComponentVersion(hustVersion, hustCommit, { includeCommit: false });
+        const hustDisplayVersion = resolveVersionDisplayValue(
+            hustVersion,
+            hustCommit,
+            engineSource.ref,
+            {
+                overrideVersion: getHistoricalSameSpecVersionOverride(
+                    dataSource,
+                    'vllm-hust',
+                    engineSource.repository
+                ),
+                fallbackToRecordedRevision: hasHustEngineRepository,
+                missingValue: engineName === 'vllm-hust' && hasHustPluginRepository ? 'unrecorded' : '',
+            }
+        );
         if (hustDisplayVersion) {
             components.push({
                 label: 'vllm-hust',
                 version: hustDisplayVersion,
+                visibilityKey: buildComponentVisibilityKey(
+                    'vllm-hust',
+                    hustDisplayVersion,
+                    hustCommit,
+                    engineSource.ref
+                ),
             });
         }
 
-        const ascendHustVersion = hasVersionValue(versions.backend)
+        const ascendHustVersion = hasRenderablePackageVersion(versions.backend)
             ? versions.backend
-            : ((isHustPlugin || engineName === 'vllm-ascend-hust') ? engineVersion : '');
-        const ascendHustCommit = runtime?.plugin?.commit
-            || ((isHustPlugin || engineName === 'vllm-ascend-hust') ? getEntryGitCommit(entry) : '')
+            : (canUseEngineVersionForPlugin ? engineVersion : '');
+        const ascendHustCommit = pluginSource.commit
             || extractCommitFromVersion(versions.backend)
             || extractCommitFromVersion(engineVersion);
 
-        const ascendHustDisplayVersion = formatComponentVersion(ascendHustVersion, ascendHustCommit, { includeCommit: false });
+        const ascendHustDisplayVersion = resolveVersionDisplayValue(
+            ascendHustVersion,
+            ascendHustCommit,
+            pluginSource.ref,
+            {
+                overrideVersion: getHistoricalSameSpecVersionOverride(
+                    dataSource,
+                    'vllm-ascend-hust',
+                    pluginSource.repository
+                ),
+                fallbackToRecordedRevision: hasHustPluginRepository,
+            }
+        );
         if (ascendHustDisplayVersion) {
             components.push({
                 label: 'vllm-ascend-hust',
                 version: ascendHustDisplayVersion,
+                visibilityKey: buildComponentVisibilityKey(
+                    'vllm-ascend-hust',
+                    ascendHustDisplayVersion,
+                    ascendHustCommit,
+                    pluginSource.ref
+                ),
             });
         }
 
@@ -785,6 +957,16 @@
         const rows = components.map((component) => renderAlignedVersionRow(component)).join('');
         const dateLine = dateLabel ? `<small class="version-date version-date--aligned">${dateLabel}</small>` : '';
         return `${rows}${dateLine}`;
+    }
+
+    function getTableVersionVisibilityKey(entry) {
+        const components = buildTableVersionComponents(entry);
+        if (components.length) {
+            return components
+                .map((component) => component.visibilityKey || `${component.label}:${component.version}`)
+                .join('|');
+        }
+        return formatEntryVersion(entry, { display: true });
     }
 
     function getSameSpecPayload(entry) {
@@ -1449,8 +1631,8 @@
         tbody.innerHTML = withTrends.map((entry, index) => {
             const isLatest = index === 0;
             const isExpanded = state.expandedRows.has(entry.entry_id);
-            const currentVersion = getDisplayVersion(entry);
-            const prevVersion = index > 0 ? getDisplayVersion(withTrends[index - 1]) : null;
+            const currentVersion = getTableVersionVisibilityKey(entry);
+            const prevVersion = index > 0 ? getTableVersionVisibilityKey(withTrends[index - 1]) : null;
             const showVersionForEveryRow = typeof window !== 'undefined'
                 && new URLSearchParams(window.location.search).get('showVersionAll') === '1';
             const showVersion = showVersionForEveryRow || index === 0 || currentVersion !== prevVersion;

--- a/index.html
+++ b/index.html
@@ -2363,6 +2363,6 @@
     <script src="./assets/workstation-embed.js"></script>
 
     <!-- Leaderboard Script -->
-    <script src="./assets/leaderboard.js?v=hc-best-scope-rank-20260514"></script>
+    <script src="./assets/leaderboard.js?v=leaderboard-version-fix-20260523-4"></script>
   </body>
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -83,8 +84,8 @@ def test_index_cache_busts_leaderboard_script() -> None:
     root = Path(__file__).resolve().parents[1]
     text = (root / "index.html").read_text(encoding="utf-8")
 
-    assert "./assets/hf-data-loader.js?v=compare-source-guard-20260513" in text
-    assert "./assets/leaderboard.js?v=hc-best-scope-rank-20260514" in text
+    assert re.search(r'\.\/assets\/hf-data-loader\.js\?v=[^"\']+', text)
+    assert re.search(r'\.\/assets\/leaderboard\.js\?v=[^"\']+', text)
 
 
 def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> None:


### PR DESCRIPTION
## Summary
- restore GitHub snapshot version rendering when snapshot rows are missing core/backend package versions
- avoid blank first-column version blocks when adjacent rows share the same semantic family but differ by commit/ref
- relax the site structure cache-bust assertion so the leaderboard asset can be version-bumped without rewriting the test

## Validation
- python3 -m py_compile tests/test_site_structure.py
- git diff --check
- local preview/manual verification for the GitHub snapshot rows discussed in this thread (`?dataSource=github`)
