### PR TITLE
fix(website): polish overview card meta

### DIFF
--- a/assets/leaderboard.css
+++ b/assets/leaderboard.css
@@ -595,11 +595,14 @@
     display: inline-flex;
     align-items: center;
     padding: 6px 10px;
+    max-width: 100%;
     border-radius: 999px;
     background: #eff6ff;
     color: #1d4ed8;
     font-size: 0.86rem;
     font-weight: 700;
+    line-height: 1.25;
+    white-space: normal;
 }
 
 .leader-mark {
@@ -614,9 +617,27 @@
 }
 
 .engine-summary-version {
-    color: #475569;
-    font-size: 0.92rem;
-    margin-bottom: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: #0f172a;
+    font-size: 0.94rem;
+    font-weight: 600;
+    line-height: 1.45;
+    margin: 0;
+}
+
+.engine-summary-version-label {
+    color: #64748b;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.engine-summary-version-value {
+    color: #0f172a;
+    font-size: 0.94rem;
+    font-weight: 600;
+    line-height: 1.45;
 }
 
 .engine-summary-metrics {
@@ -648,11 +669,43 @@
     line-height: 1.2;
 }
 
-.engine-summary-footer {
+.engine-summary-meta {
     margin-top: 14px;
+    padding: 14px 16px;
+    border-radius: 16px;
+    background: linear-gradient(180deg, #f8fbff 0%, #f1f5f9 100%);
+    border: 1px solid #dbe7f3;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.engine-summary-card.is-leader .engine-summary-meta {
+    background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 100%);
+    border-color: #bfdbfe;
+}
+
+.engine-summary-footer {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
     color: #475569;
     font-size: 0.88rem;
     line-height: 1.5;
+}
+
+.engine-summary-footer-label {
+    color: #64748b;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.engine-summary-footer-value {
+    color: #0f172a;
+    font-size: 0.94rem;
+    font-weight: 600;
+    line-height: 1.45;
 }
 
 .leaderboard-hint {

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -166,6 +166,8 @@
             throughputLeader: 'Throughput leader',
             rowCount: 'rows',
             bestVisibleVersion: 'Best visible version',
+            currentBestVersionLabel: 'Current best version: ',
+            baselineVersionLabel: 'Baseline version: ',
             avgTTFT: 'Avg TTFT',
             avgTBT: 'Avg TBT',
             avgThroughput: 'Avg Throughput',
@@ -326,6 +328,8 @@
             throughputLeader: '吞吐领先',
             rowCount: '条记录',
             bestVisibleVersion: '当前最佳可见版本',
+            currentBestVersionLabel: '当前最佳版本：',
+            baselineVersionLabel: '基线版本：',
             avgTTFT: '平均 TTFT',
             avgTBT: '平均 TBT',
             avgThroughput: '平均吞吐',
@@ -857,21 +861,22 @@
         const hustVersion = hasRenderablePackageVersion(versions.core)
             ? versions.core
             : (canUseEngineVersionForHust ? engineVersion : '');
-    const hustCommit = engineSource.commit
-        || (canUseEngineVersionForHust ? getEntryGitCommit(entry) : '')
+        const hustCommit = engineSource.commit
+            || (canUseEngineVersionForHust ? getEntryGitCommit(entry) : '')
             || extractCommitFromVersion(versions.core)
             || extractCommitFromVersion(engineVersion);
+        const hustOverrideVersion = getHistoricalSameSpecVersionOverride(
+            dataSource,
+            'vllm-hust',
+            engineSource.repository
+        );
 
         const hustDisplayVersion = resolveVersionDisplayValue(
             hustVersion,
             hustCommit,
             engineSource.ref,
             {
-                overrideVersion: getHistoricalSameSpecVersionOverride(
-                    dataSource,
-                    'vllm-hust',
-                    engineSource.repository
-                ),
+                overrideVersion: hustOverrideVersion,
                 fallbackToRecordedRevision: hasHustEngineRepository,
                 missingValue: engineName === 'vllm-hust' && hasHustPluginRepository ? 'unrecorded' : '',
             }
@@ -880,6 +885,10 @@
             components.push({
                 label: 'vllm-hust',
                 version: hustDisplayVersion,
+                rawVersion: hustVersion,
+                overrideVersion: hustOverrideVersion,
+                commit: hustCommit,
+                ref: engineSource.ref,
                 visibilityKey: buildComponentVisibilityKey(
                     'vllm-hust',
                     hustDisplayVersion,
@@ -892,21 +901,22 @@
         const ascendHustVersion = hasRenderablePackageVersion(versions.backend)
             ? versions.backend
             : (canUseEngineVersionForPlugin ? engineVersion : '');
-    const ascendHustCommit = pluginSource.commit
-        || (canUseEngineVersionForPlugin ? getEntryGitCommit(entry) : '')
+        const ascendHustCommit = pluginSource.commit
+            || (canUseEngineVersionForPlugin ? getEntryGitCommit(entry) : '')
             || extractCommitFromVersion(versions.backend)
             || extractCommitFromVersion(engineVersion);
+        const ascendHustOverrideVersion = getHistoricalSameSpecVersionOverride(
+            dataSource,
+            'vllm-ascend-hust',
+            pluginSource.repository
+        );
 
         const ascendHustDisplayVersion = resolveVersionDisplayValue(
             ascendHustVersion,
             ascendHustCommit,
             pluginSource.ref,
             {
-                overrideVersion: getHistoricalSameSpecVersionOverride(
-                    dataSource,
-                    'vllm-ascend-hust',
-                    pluginSource.repository
-                ),
+                overrideVersion: ascendHustOverrideVersion,
                 fallbackToRecordedRevision: hasHustPluginRepository,
             }
         );
@@ -914,6 +924,10 @@
             components.push({
                 label: 'vllm-ascend-hust',
                 version: ascendHustDisplayVersion,
+                rawVersion: ascendHustVersion,
+                overrideVersion: ascendHustOverrideVersion,
+                commit: ascendHustCommit,
+                ref: pluginSource.ref,
                 visibilityKey: buildComponentVisibilityKey(
                     'vllm-ascend-hust',
                     ascendHustDisplayVersion,
@@ -938,11 +952,17 @@
             components.push({
                 label: engineName === 'vllm' ? 'vllm' : getEngineLabel(engineName),
                 version: officialVersion,
+                rawVersion: engineVersion || metadata.github_ref || '',
+                commit: sharedSource.commit,
+                ref: sharedSource.ref,
             });
             if (isOfficialAscendStack) {
                 components.push({
                     label: 'vllm-ascend',
                     version: officialVersion,
+                    rawVersion: engineVersion || metadata.github_ref || '',
+                    commit: sharedSource.commit,
+                    ref: sharedSource.ref,
                 });
             }
         }
@@ -969,6 +989,72 @@
                 .join('|');
         }
         return formatEntryVersion(entry, { display: true });
+    }
+
+    function shouldIncludeCommitInOverview(label) {
+        return label === 'vllm-hust' || label === 'vllm-ascend-hust';
+    }
+
+    function formatOverviewComponentVersion(component) {
+        if (!component?.label) {
+            return '';
+        }
+
+        const includeCommit = shouldIncludeCommitInOverview(component.label);
+        const versionCandidates = [component.rawVersion, component.overrideVersion]
+            .map((value) => String(value || '').trim())
+            .filter(Boolean);
+
+        let resolvedVersion = '';
+        for (const candidate of versionCandidates) {
+            resolvedVersion = formatComponentVersion(candidate, component.commit, { includeCommit });
+            if (resolvedVersion) {
+                break;
+            }
+        }
+
+        if (!resolvedVersion) {
+            for (const candidate of versionCandidates) {
+                resolvedVersion = formatComponentVersion(candidate, component.commit, { includeCommit: false });
+                if (resolvedVersion) {
+                    break;
+                }
+            }
+        }
+
+        if (!resolvedVersion) {
+            resolvedVersion = String(component.version || '').trim();
+        }
+
+        if (!resolvedVersion) {
+            return '';
+        }
+
+        return resolvedVersion;
+    }
+
+    function getOverviewSummaryChipText(summary) {
+        const labels = (summary?.overviewComponents || [])
+            .map((component) => String(component?.label || '').trim())
+            .filter(Boolean);
+
+        if (labels.length) {
+            return labels.join(' + ');
+        }
+
+        return summary?.label || '';
+    }
+
+    function getOverviewSummaryVersionText(summary) {
+        const parts = (summary?.overviewComponents || [])
+            .map((component) => formatOverviewComponentVersion(component))
+            .filter(Boolean);
+
+        if (parts.length) {
+            return parts.join(' + ');
+        }
+
+        return summary?.version || '';
     }
 
     function getSameSpecPayload(entry) {
@@ -1720,7 +1806,7 @@
                 <div class="overview-section-label">${t('overviewGridLabel')}</div>
                 <div class="overview-section-note">${t('overviewGridNote')}</div>
                 <div class="overview-grid">
-                    ${summaries.map((summary) => renderEngineSummaryCard(summary, leaders)).join('')}
+                    ${summaries.map((summary, index) => renderEngineSummaryCard(summary, leaders, index, summaries.length)).join('')}
                 </div>
             </div>
         `;
@@ -2601,6 +2687,7 @@
                     avgTPS: averageMetric(engineEntries, 'throughput_tps'),
                     avgError: averageMetric(engineEntries, 'error_rate'),
                     bestEntry,
+                    overviewComponents: buildTableVersionComponents(bestEntry),
                     version: formatEntryVersion(bestEntry, { display: true }),
                 };
             })
@@ -2936,17 +3023,23 @@
         return isBetter ? `${label} ${t('better')}` : `${label} ${t('worse')}`;
     }
 
-    function renderEngineSummaryCard(summary, leaders) {
+    function renderEngineSummaryCard(summary, leaders, cardIndex, cardCount) {
         const bestEntry = summary.bestEntry || {};
         const isLeader = leaders.throughput && leaders.throughput.engine === summary.engine;
+        const isBaselineCard = !isLeader && cardCount === 2 && cardIndex === 1;
+        const chipText = getOverviewSummaryChipText(summary);
+        const versionText = getOverviewSummaryVersionText(summary);
+        const bestVisibleRunText = `${getWorkloadLabel(getWorkloadId(bestEntry))} • ${getConfigText(bestEntry).replace('<br><small>', ' • ').replace('</small>', '')}`;
+        const versionPrefix = isLeader
+            ? t('currentBestVersionLabel')
+            : (isBaselineCard ? t('baselineVersionLabel') : `${t('bestVisibleVersion')} `);
 
         return `
             <div class="engine-summary-card ${isLeader ? 'is-leader' : ''}">
                 <div class="engine-summary-head">
-                    <span class="engine-chip">${summary.label}</span>
+                    <span class="engine-chip">${chipText}</span>
                     ${isLeader ? `<span class="leader-mark">${t('throughputLeader')}</span>` : `<span class="leader-mark">${summary.count} ${summary.count > 1 ? t('rows') : t('row')}</span>`}
                 </div>
-                <div class="engine-summary-version">${t('bestVisibleVersion')} ${summary.version}</div>
                 <div class="engine-summary-metrics">
                     <div class="summary-metric">
                         <span>${t('avgTTFT')}</span>
@@ -2965,8 +3058,15 @@
                         <strong>${formatPercent(summary.avgError)}</strong>
                     </div>
                 </div>
-                <div class="engine-summary-footer">
-                    ${t('bestVisibleRun')}: ${getWorkloadLabel(getWorkloadId(bestEntry))} • ${getConfigText(bestEntry).replace('<br><small>', ' • ').replace('</small>', '')}
+                <div class="engine-summary-meta">
+                    <div class="engine-summary-version">
+                        <span class="engine-summary-version-label">${versionPrefix}</span>
+                        <span class="engine-summary-version-value">${versionText}</span>
+                    </div>
+                    <div class="engine-summary-footer">
+                        <span class="engine-summary-footer-label">${t('bestVisibleRun')}:</span>
+                        <span class="engine-summary-footer-value">${bestVisibleRunText}</span>
+                    </div>
                 </div>
             </div>
         `;

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -89,6 +89,42 @@ def test_index_cache_busts_leaderboard_script() -> None:
     assert re.search(r'\.\/assets\/leaderboard\.css\?v=[^"\']+', text)
 
 
+def test_engine_summary_cards_use_composite_version_components() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
+    css_text = (root / "assets" / "leaderboard.css").read_text(encoding="utf-8")
+
+    assert "function formatOverviewComponentVersion(component)" in text
+    assert "function getOverviewSummaryChipText(summary)" in text
+    assert "function getOverviewSummaryVersionText(summary)" in text
+    assert 'return resolvedVersion;' in text
+    assert "overviewComponents: buildTableVersionComponents(bestEntry)" in text
+    assert 'const chipText = getOverviewSummaryChipText(summary);' in text
+    assert 'const versionText = getOverviewSummaryVersionText(summary);' in text
+    assert 'const bestVisibleRunText =' in text
+    assert "currentBestVersionLabel" in text
+    assert "baselineVersionLabel" in text
+    assert "const isBaselineCard = !isLeader && cardCount === 2 && cardIndex === 1;" in text
+    assert 'const versionPrefix = isLeader' in text
+    assert '<div class="engine-summary-meta">' in text
+    assert '<span class="engine-summary-version-label">${versionPrefix}</span>' in text
+    assert '<span class="engine-summary-version-value">${versionText}</span>' in text
+    assert '<span class="engine-summary-footer-label">${t(\'bestVisibleRun\')}:</span>' in text
+    assert '<span class="engine-summary-footer-value">${bestVisibleRunText}</span>' in text
+    metrics_index = text.index('<div class="engine-summary-metrics">')
+    meta_index = text.index('<div class="engine-summary-meta">')
+    version_index = text.index('<div class="engine-summary-version">')
+    footer_index = text.index('<div class="engine-summary-footer">')
+    assert metrics_index < meta_index < version_index < footer_index
+    assert '.engine-summary-meta {' in css_text
+    assert '.engine-summary-version-label {' in css_text
+    assert '.engine-summary-version-value {' in css_text
+    assert '.engine-summary-footer-label {' in css_text
+    assert '.engine-summary-footer-value {' in css_text
+    assert 'font-size: 0.94rem;' in css_text
+    assert 'font-weight: 600;' in css_text
+
+
 def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> None:
     root = Path(__file__).resolve().parents[1]
     text = (root / "index.html").read_text(encoding="utf-8")

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -104,13 +104,22 @@ def test_engine_summary_cards_use_composite_version_components() -> None:
     assert 'const bestVisibleRunText =' in text
     assert "currentBestVersionLabel" in text
     assert "baselineVersionLabel" in text
-    assert "const isBaselineCard = !isLeader && cardCount === 2 && cardIndex === 1;" in text
+    assert (
+        "const isBaselineCard = !isLeader && cardCount === 2 && cardIndex === 1;"
+        in text
+    )
     assert 'const versionPrefix = isLeader' in text
     assert '<div class="engine-summary-meta">' in text
     assert '<span class="engine-summary-version-label">${versionPrefix}</span>' in text
     assert '<span class="engine-summary-version-value">${versionText}</span>' in text
-    assert '<span class="engine-summary-footer-label">${t(\'bestVisibleRun\')}:</span>' in text
-    assert '<span class="engine-summary-footer-value">${bestVisibleRunText}</span>' in text
+    assert (
+        '<span class="engine-summary-footer-label">${t(\'bestVisibleRun\')}:</span>'
+        in text
+    )
+    assert (
+        '<span class="engine-summary-footer-value">${bestVisibleRunText}</span>'
+        in text
+    )
     metrics_index = text.index('<div class="engine-summary-metrics">')
     meta_index = text.index('<div class="engine-summary-meta">')
     version_index = text.index('<div class="engine-summary-version">')

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -97,41 +97,40 @@ def test_engine_summary_cards_use_composite_version_components() -> None:
     assert "function formatOverviewComponentVersion(component)" in text
     assert "function getOverviewSummaryChipText(summary)" in text
     assert "function getOverviewSummaryVersionText(summary)" in text
-    assert 'return resolvedVersion;' in text
+    assert "return resolvedVersion;" in text
     assert "overviewComponents: buildTableVersionComponents(bestEntry)" in text
-    assert 'const chipText = getOverviewSummaryChipText(summary);' in text
-    assert 'const versionText = getOverviewSummaryVersionText(summary);' in text
-    assert 'const bestVisibleRunText =' in text
+    assert "const chipText = getOverviewSummaryChipText(summary);" in text
+    assert "const versionText = getOverviewSummaryVersionText(summary);" in text
+    assert "const bestVisibleRunText =" in text
     assert "currentBestVersionLabel" in text
     assert "baselineVersionLabel" in text
     assert (
         "const isBaselineCard = !isLeader && cardCount === 2 && cardIndex === 1;"
         in text
     )
-    assert 'const versionPrefix = isLeader' in text
+    assert "const versionPrefix = isLeader" in text
     assert '<div class="engine-summary-meta">' in text
     assert '<span class="engine-summary-version-label">${versionPrefix}</span>' in text
     assert '<span class="engine-summary-version-value">${versionText}</span>' in text
     assert (
-        '<span class="engine-summary-footer-label">${t(\'bestVisibleRun\')}:</span>'
+        "<span class=\"engine-summary-footer-label\">${t('bestVisibleRun')}:</span>"
         in text
     )
     assert (
-        '<span class="engine-summary-footer-value">${bestVisibleRunText}</span>'
-        in text
+        '<span class="engine-summary-footer-value">${bestVisibleRunText}</span>' in text
     )
     metrics_index = text.index('<div class="engine-summary-metrics">')
     meta_index = text.index('<div class="engine-summary-meta">')
     version_index = text.index('<div class="engine-summary-version">')
     footer_index = text.index('<div class="engine-summary-footer">')
     assert metrics_index < meta_index < version_index < footer_index
-    assert '.engine-summary-meta {' in css_text
-    assert '.engine-summary-version-label {' in css_text
-    assert '.engine-summary-version-value {' in css_text
-    assert '.engine-summary-footer-label {' in css_text
-    assert '.engine-summary-footer-value {' in css_text
-    assert 'font-size: 0.94rem;' in css_text
-    assert 'font-weight: 600;' in css_text
+    assert ".engine-summary-meta {" in css_text
+    assert ".engine-summary-version-label {" in css_text
+    assert ".engine-summary-version-value {" in css_text
+    assert ".engine-summary-footer-label {" in css_text
+    assert ".engine-summary-footer-value {" in css_text
+    assert "font-size: 0.94rem;" in css_text
+    assert "font-weight: 600;" in css_text
 
 
 def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> None:


### PR DESCRIPTION
## Summary
- refine leaderboard overview cards so version info and best-run info render as a grouped meta block
- move overview version text to value-only rendering by removing engine-name prefixes from the version-value field
- align footer value typography with version value and keep regression coverage for the updated DOM structure

## Validation
- `git diff --check`
- `python3 -m py_compile tests/test_site_structure.py`
- local browser verification against `http://127.0.0.1:8023/index.html?dataSource=github`
  - leader version value: `v0.20.1rc1.7fa0e3ed + v0.1.c56ccf1e`
  - baseline version value: `v0.11.0 + v0.11.0`
  - leader/footer and baseline/footer value typography match `font-size`, `font-weight`, `line-height`, and `color`
- `python3 -m pytest tests/test_site_structure.py -q` could not run because `pytest` is not installed in the current environment

## Notes
- merging this PR into `main` will trigger the website update workflow
