### PR TITLE
fix(website): bust cached overview assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
       rel="stylesheet"
     />
 
-    <!-- Leaderboard Styles -->
-    <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-responsive-20260523-2" />
+    <!-- Leaderboard Styles: bump ?v whenever leaderboard.css changes to bust browser/GitHub Pages caches -->
+    <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-overview-meta-20260523-1" />
 
     <style>
       * {
@@ -2362,7 +2362,7 @@
     <!-- Workstation Embed Loader -->
     <script src="./assets/workstation-embed.js"></script>
 
-    <!-- Leaderboard Script -->
-  <script src="./assets/leaderboard.js?v=leaderboard-version-fix-20260523-5"></script>
+    <!-- Leaderboard Script: bump ?v whenever leaderboard.js changes to bust browser/GitHub Pages caches -->
+  <script src="./assets/leaderboard.js?v=leaderboard-overview-meta-20260523-1"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- bump the cache-busting query strings for leaderboard CSS and JS in index.html
- document near the asset tags that the version suffix must change whenever leaderboard assets change

## Root cause
PR #50 changed assets/leaderboard.js and assets/leaderboard.css, but it did not change the asset URLs referenced by index.html. Browsers that had already cached those URLs kept serving the old files, so the merged overview-card UI changes did not appear without a hard refresh or cache expiry.

## Validation
- uvx --with pytest pytest tests/test_site_structure.py -k index_cache_busts_leaderboard_script -v

## AI assistance
- Assisted by GitHub Copilot
