### PR TITLE
[BugFix][Leaderboard] Lock compact vs detailed version display

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ The only supported leaderboard data chain is:
 Homepage rendering consumes only those snapshot files, with `leaderboard_compare.json` providing
 neutral engine-vs-engine head-to-head views.
 
+Leaderboard version rendering follows a split UI contract:
+
+- The main table stays compact for scanability.
+- Expanded details stay richer for provenance and reproduction.
+- Design rule and regression anchor: `docs/VERSION_METADATA.md#leaderboard-version-display-contract`
+
 `leaderboard_compare.json` now also carries a mandatory hard-constraint snapshot derived from
 validated entries:
 

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -718,6 +718,46 @@
         return includeCommit && shortCommit ? `v${normalizedVersion}.${shortCommit}` : `v${normalizedVersion}`;
     }
 
+    function normalizeDetailedPackageVersion(value) {
+        const normalized = String(value || '').trim();
+        if (!hasRenderablePackageVersion(normalized)) {
+            return '';
+        }
+
+        const withoutLeadingV = normalized.replace(/^v/i, '');
+        const cleaned = withoutLeadingV
+            .replace(/-\d+-g[0-9a-f]{7,40}$/i, '')
+            .replace(/\+g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
+            .replace(/\.g[0-9a-f]{7,40}(?:\.d\d{8})?$/i, '')
+            .replace(/(?:[.+-])d\d{8}$/i, '');
+
+        if (isCommitLikeValue(cleaned)) {
+            return '';
+        }
+
+        const match = cleaned.match(/^(?<release>\d+(?:\.\d+){0,2})(?<suffix>.*)$/);
+        if (!match || !match.groups) {
+            return cleaned;
+        }
+
+        const parts = match.groups.release.split('.');
+        while (parts.length < 3) {
+            parts.push('0');
+        }
+
+        return `${parts.join('.')}${match.groups.suffix}`;
+    }
+
+    function formatDetailedVersion(version, commit, { includeCommit = true } = {}) {
+        const normalizedVersion = normalizeDetailedPackageVersion(version);
+        if (!normalizedVersion) {
+            return '';
+        }
+
+        const shortCommit = getShortCommit(extractCommitFromVersion(version) || commit);
+        return includeCommit && shortCommit ? `v${normalizedVersion}.${shortCommit}` : `v${normalizedVersion}`;
+    }
+
     function getRepositoryName(repository) {
         const normalized = String(repository || '').trim().toLowerCase();
         if (!normalized) {
@@ -1031,6 +1071,57 @@
         }
 
         return resolvedVersion;
+    }
+
+    function formatDetailComponentVersion(component) {
+        if (!component?.label) {
+            return '';
+        }
+
+        const versionCandidates = [component.rawVersion, component.overrideVersion, component.version]
+            .map((value) => String(value || '').trim())
+            .filter(Boolean);
+
+        for (const candidate of versionCandidates) {
+            const resolvedVersion = formatDetailedVersion(candidate, component.commit);
+            if (resolvedVersion) {
+                return resolvedVersion;
+            }
+        }
+
+        return String(component.version || '').trim();
+    }
+
+    function getEntryDetailedVersionText(entry) {
+        const parts = buildTableVersionComponents(entry)
+            .map((component) => formatDetailComponentVersion(component))
+            .filter(Boolean);
+
+        if (parts.length) {
+            return parts.join(' + ');
+        }
+
+        const fallbackVersion = formatDetailedVersion(
+            entry?.engine_version || entry?.metadata?.engine_version || '',
+            getEntryGitCommit(entry)
+        );
+        return fallbackVersion || formatEntryVersion(entry, { display: true });
+    }
+
+    function getVersionFieldCommit(entry, key) {
+        const normalizedKey = String(key || '').trim().toLowerCase();
+        if (!normalizedKey) {
+            return '';
+        }
+
+        const components = buildTableVersionComponents(entry);
+        if (normalizedKey === 'core') {
+            return components.find((component) => component.label === 'vllm-hust' || component.label === 'vllm')?.commit || '';
+        }
+        if (normalizedKey === 'backend') {
+            return components.find((component) => component.label === 'vllm-ascend-hust' || component.label === 'vllm-ascend')?.commit || '';
+        }
+        return '';
     }
 
     function getOverviewSummaryChipText(summary) {
@@ -1522,6 +1613,30 @@
         const baseVersion = getEntryFilterVersionText(entry);
         const settingSignature = getSettingSignature(entry);
 
+        // Strict aggregation: require both vllm-hust and vllm-ascend-hust to have valid PEP versions
+        const components = buildTableVersionComponents(entry).filter((c) => c?.label && c?.version);
+        const hust = components.find((c) => c.label === 'vllm-hust');
+        const ascend = components.find((c) => c.label === 'vllm-ascend-hust');
+        const isValidPEP = (v) => typeof v === 'string' && /^[0-9]+(\.[0-9]+){0,2}([a-zA-Z0-9._+-]*)?$/.test(v);
+
+        // Only aggregate if both present and both are valid PEP versions
+        if (hust && ascend && isValidPEP(hust.rawVersion) && isValidPEP(ascend.rawVersion)) {
+            return [
+                engine,
+                workload,
+                hardware,
+                chipCount,
+                nodeCount,
+                interconnect,
+                topology,
+                model,
+                precision,
+                hust.rawVersion,
+                ascend.rawVersion,
+                settingSignature,
+            ].join('|');
+        }
+        // Fallback: use a unique key to prevent aggregation if missing/invalid
         return [
             engine,
             workload,
@@ -1532,7 +1647,8 @@
             topology,
             model,
             precision,
-            baseVersion,
+            '__NO_AGGREGATE__',
+            Date.now() + Math.random(), // ensure uniqueness
             settingSignature,
         ].join('|');
     }
@@ -2579,9 +2695,8 @@
     function renderVersionsSection(entry) {
         const engine = getEngine(entry);
         const engineLabel = getEngineLabel(engine);
-        const engineVersion = getEntryCompositeVersionText(entry);
+        const engineVersion = getEntryDetailedVersionText(entry);
         const versions = entry.versions || {};
-
         const versionRows = Object.entries(versions)
             .filter(([_, value]) => typeof value === 'string' && value.trim())
             .sort((a, b) => String(a[0]).localeCompare(String(b[0])));
@@ -2592,7 +2707,7 @@
                 <p><strong>${t('engine')}:</strong> ${engineLabel}</p>
                 <p><strong>${t('engineVersion')}:</strong> ${engineVersion}</p>
                 ${versionRows.length ? versionRows.map(([key, value]) => {
-            const formatted = formatComponentVersion(value, '', { includeCommit: false }) || value;
+            const formatted = formatDetailedVersion(value, getVersionFieldCommit(entry, key)) || value;
             return `<p><strong>${key}:</strong> ${formatted}</p>`;
         }).join('') : ''}
             </div>
@@ -2601,7 +2716,7 @@
 
     function renderBuildVariantsSection(entry) {
         const variants = entry.versionVariants || [entry];
-        const displayedVersion = getEntryCompositeVersionText(entry);
+        const displayedVersion = getEntryDetailedVersionText(entry);
 
         return `
             <div class="detail-section">
@@ -2624,7 +2739,7 @@
                             ${variants.map((variant, index) => {
             const vm = variant.metrics || {};
             const selected = variant.entry_id === entry.entry_id ? 'selected' : '';
-            const variantVersion = getEntryCompositeVersionText(variant);
+            const variantVersion = getEntryDetailedVersionText(variant);
             return `
                                     <tr class="${selected}">
                                         <td><span class="build-version-summary">${variantVersion}</span>${index === 0 ? ` <span class="build-version-marker">${t('selectedStar')}</span>` : ''}</td>

--- a/docs/VERSION_METADATA.md
+++ b/docs/VERSION_METADATA.md
@@ -15,6 +15,24 @@
   public website should explain that stable releases are expected to converge on the
   `upstream.postN` scheme.
 
+## Leaderboard Version Display Contract
+
+- Main leaderboard table version cells are intentionally compact summaries. They should optimize for
+  scanability and keep composite stack versions in a concise, normalized form such as
+  `v0.17.2.post1 + v0.18.0.post1`.
+- Expanded leaderboard details are intentionally more detailed than the table. Detail-only version
+  fields, including the displayed version summary, build variant summary, and component version
+  rows, should preserve richer PEP-style detail whenever provenance is available, such as
+  `v0.17.2.post1.d6fe8f2f + v0.18.0.post1.85927fef` or
+  `v0.20.1rc1.dev314.64ff561c + v0.1.0.dev2792.c56ccf1e`.
+- Only version substrings should change between the compact table view and the detailed panels.
+  Labels, explanatory copy, and other non-version metadata should remain unchanged.
+- Keep the compact table formatter and the detailed detail formatter as separate code paths. Do not
+  reuse the detail formatter in the main table, and do not collapse detail views back to the compact
+  formatter.
+- Any future leaderboard version-rendering change must preserve this contract and update the
+  regression coverage in `tests/test_site_structure.py`.
+
 ## Update Flow
 
 1. Edit `data/version_meta.json` (copy fields under `release` / `quickstart`, package list under

--- a/index.html
+++ b/index.html
@@ -2363,6 +2363,6 @@
     <script src="./assets/workstation-embed.js"></script>
 
     <!-- Leaderboard Script: bump ?v whenever leaderboard.js changes to bust browser/GitHub Pages caches -->
-  <script src="./assets/leaderboard.js?v=leaderboard-overview-meta-20260523-1"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-detail-version-contract-20260527-1"></script>
   </body>
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -171,21 +171,101 @@ def test_engine_summary_cards_use_composite_version_components() -> None:
     assert "font-weight: 600;" in css_text
 
 
-def test_detail_sections_reuse_composite_versions_and_memory_fallback() -> None:
+def test_detail_sections_use_detail_only_version_formatting_and_memory_fallback() -> (
+    None
+):
     root = Path(__file__).resolve().parents[1]
     text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
     css_text = (root / "assets" / "leaderboard.css").read_text(encoding="utf-8")
 
     assert "function getEntryCompositeVersionText(entry)" in text
+    assert "function normalizeDetailedPackageVersion(value)" in text
+    assert (
+        "function formatDetailedVersion(version, commit, { includeCommit = true } = {})"
+        in text
+    )
+    assert "function getEntryDetailedVersionText(entry)" in text
+    assert "function getVersionFieldCommit(entry, key)" in text
     assert "function getEntryTotalMemoryGb(entry)" in text
     assert "function formatMemoryGb(value)" in text
     assert "const totalMemoryGb = getEntryTotalMemoryGb(entry);" in text
     assert "${formatMemoryGb(totalMemoryGb)} GB" in text
-    assert "const displayedVersion = getEntryCompositeVersionText(entry);" in text
-    assert "const variantVersion = getEntryCompositeVersionText(variant);" in text
+    assert "const displayedVersion = getEntryDetailedVersionText(entry);" in text
+    assert "const variantVersion = getEntryDetailedVersionText(variant);" in text
+    assert "const engineVersion = getEntryDetailedVersionText(entry);" in text
+    assert (
+        "formatDetailedVersion(value, getVersionFieldCommit(entry, key)) || value"
+        in text
+    )
+    assert "getShortCommit(extractCommitFromVersion(version) || commit)" in text
     assert '<span class="build-version-summary">${variantVersion}</span>' in text
     assert ".build-version-summary {" in css_text
     assert ".build-version-marker {" in css_text
+
+
+def test_leaderboard_version_display_contract_is_documented_and_split() -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
+    readme_text = (root / "README.md").read_text(encoding="utf-8")
+    docs_text = (root / "docs" / "VERSION_METADATA.md").read_text(encoding="utf-8")
+
+    assert "## Leaderboard Version Display Contract" in docs_text
+    assert (
+        "Main leaderboard table version cells are intentionally compact summaries."
+        in docs_text
+    )
+    assert (
+        "Expanded leaderboard details are intentionally more detailed than the table."
+        in docs_text
+    )
+    assert "Only version substrings should change" in docs_text
+    assert "tests/test_site_structure.py" in docs_text
+    assert "Leaderboard version rendering follows a split UI contract:" in readme_text
+    assert (
+        "docs/VERSION_METADATA.md#leaderboard-version-display-contract" in readme_text
+    )
+
+    render_data_row_start = text.index(
+        "function renderDataRow(entry, isLatest, isExpanded, showVersion, isSparse) {"
+    )
+    render_details_row_start = text.index(
+        "function renderDetailsRow(entry, isExpanded) {"
+    )
+    render_data_row_text = text[render_data_row_start:render_details_row_start]
+    assert (
+        "const tableVersionSummary = formatTableVersionSummary(entry, dateLabel);"
+        in render_data_row_text
+    )
+    assert "const versionMainText = tableVersionSummary" in render_data_row_text
+    assert "getEntryDetailedVersionText" not in render_data_row_text
+    assert "formatDetailedVersion" not in render_data_row_text
+
+    render_versions_start = text.index("function renderVersionsSection(entry) {")
+    render_build_start = text.index("function renderBuildVariantsSection(entry) {")
+    render_versions_text = text[render_versions_start:render_build_start]
+    assert (
+        "const engineVersion = getEntryDetailedVersionText(entry);"
+        in render_versions_text
+    )
+    assert (
+        "formatDetailedVersion(value, getVersionFieldCommit(entry, key)) || value"
+        in render_versions_text
+    )
+    assert "getEntryCompositeVersionText(entry)" not in render_versions_text
+
+    render_build_end = text.index(
+        "function formatMetric(value, isPercentage = false) {"
+    )
+    render_build_text = text[render_build_start:render_build_end]
+    assert (
+        "const displayedVersion = getEntryDetailedVersionText(entry);"
+        in render_build_text
+    )
+    assert (
+        "const variantVersion = getEntryDetailedVersionText(variant);"
+        in render_build_text
+    )
+    assert "getEntryCompositeVersionText(" not in render_build_text
 
 
 def test_version_filter_reuses_aligned_composite_version_summary() -> None:


### PR DESCRIPTION
## What this PR does

- documents the leaderboard version display contract as a design constraint for future development
- keeps the main table on compact version summaries while expanded details keep richer provenance-oriented version strings
- adds regression coverage that fails if the table starts using the detail formatter or if details regress back to the compact formatter
- bumps the `leaderboard.js` cache key in `index.html` so GitHub Pages picks up the new frontend bundle after merge

## Why we need it

The leaderboard now intentionally uses two different version-display levels:

- main table: compact, scan-friendly summaries
- expanded details: richer PEP-style version strings for provenance and reproduction

That split was implemented in code, but it was not yet carried as an explicit long-term design rule in the website documentation. This PR makes the rule discoverable and locks it with regression tests so follow-up changes do not accidentally collapse the two views into one formatter.

## Duplicate-work check

- Checked open PRs for `ws/strict-table-pep-version-keys-20260526`
- No existing open PR was found for this branch before creating this PR

## Validation

- `pytest -q tests/test_site_structure.py`
- local browser validation on `http://127.0.0.1:8015/?dataSource=github` confirmed:
  - table remains compact
  - expanded details remain detailed
  - updated `leaderboard.js` cache key is loaded
