### PR TITLE
fix: correct official baseline version labels

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -922,105 +922,172 @@
         const engineVersion = entry?.engine_version || metadata.engine_version || '';
         const components = [];
 
+        const isOfficialAscendStack = engineName === 'vllm'
+            && (
+                githubRepository.toLowerCase().includes('vllm-ascend')
+                || pluginRepository.includes('vllm-ascend')
+                || dataSource.includes('vllm-ascend')
+            );
+
+        if (isOfficialAscendStack) {
+            const officialCoreVersion = hasRenderablePackageVersion(versions.core)
+                ? versions.core
+                : engineVersion;
+            const officialBackendVersion = hasRenderablePackageVersion(versions.backend)
+                ? versions.backend
+                : engineVersion;
+
+            const officialCoreDisplayVersion = resolveVersionDisplayValue(
+                officialCoreVersion,
+                sharedSource.commit,
+                sharedSource.ref,
+                {
+                    fallbackToRecordedRevision: true,
+                }
+            );
+            if (officialCoreDisplayVersion) {
+                components.push({
+                    label: 'vllm',
+                    version: officialCoreDisplayVersion,
+                    rawVersion: officialCoreVersion,
+                    commit: sharedSource.commit,
+                    ref: sharedSource.ref,
+                    visibilityKey: buildComponentVisibilityKey(
+                        'vllm',
+                        officialCoreDisplayVersion,
+                        sharedSource.commit,
+                        sharedSource.ref
+                    ),
+                });
+            }
+
+            const officialBackendDisplayVersion = resolveVersionDisplayValue(
+                officialBackendVersion,
+                sharedSource.commit,
+                sharedSource.ref,
+                {
+                    fallbackToRecordedRevision: true,
+                }
+            );
+            if (officialBackendDisplayVersion) {
+                components.push({
+                    label: 'vllm-ascend',
+                    version: officialBackendDisplayVersion,
+                    rawVersion: officialBackendVersion,
+                    commit: sharedSource.commit,
+                    ref: sharedSource.ref,
+                    visibilityKey: buildComponentVisibilityKey(
+                        'vllm-ascend',
+                        officialBackendDisplayVersion,
+                        sharedSource.commit,
+                        sharedSource.ref
+                    ),
+                });
+            }
+
+            if (components.length) {
+                return components;
+            }
+        }
+
         const hasHustEngineRepository = engineRepository.includes('vllm-hust')
             || githubRepository.toLowerCase().endsWith('/vllm-hust');
         const hasHustPluginRepository = pluginEngine === 'vllm-ascend-hust'
             || pluginRepository.includes('vllm-ascend-hust')
             || githubRepository.toLowerCase().includes('vllm-ascend-hust');
+        const isHustStack = hasHustEngineRepository
+            || hasHustPluginRepository
+            || engineName === 'vllm-hust'
+            || engineName === 'vllm-ascend-hust';
         const canUseEngineVersionForHust = hasHustEngineRepository
             || (engineName === 'vllm-hust' && !hasHustPluginRepository);
         const canUseEngineVersionForPlugin = engineName === 'vllm-ascend-hust'
             || (hasHustPluginRepository && !hasHustEngineRepository);
-
-        const hustVersion = hasRenderablePackageVersion(versions.core)
-            ? versions.core
-            : (canUseEngineVersionForHust ? engineVersion : '');
-        const hustCommit = engineSource.commit
-            || (canUseEngineVersionForHust ? getEntryGitCommit(entry) : '')
-            || extractCommitFromVersion(versions.core)
-            || extractCommitFromVersion(engineVersion);
-        const hustOverrideVersion = getHistoricalSameSpecVersionOverride(
-            dataSource,
-            'vllm-hust',
-            engineSource.repository
-        );
-
-        const hustDisplayVersion = resolveVersionDisplayValue(
-            hustVersion,
-            hustCommit,
-            engineSource.ref,
-            {
-                overrideVersion: hustOverrideVersion,
-                fallbackToRecordedRevision: hasHustEngineRepository,
-                missingValue: engineName === 'vllm-hust' && hasHustPluginRepository ? 'unrecorded' : '',
-            }
-        );
-        if (hustDisplayVersion) {
-            components.push({
-                label: 'vllm-hust',
-                version: hustDisplayVersion,
-                rawVersion: hustVersion,
-                overrideVersion: hustOverrideVersion,
-                commit: hustCommit,
-                ref: engineSource.ref,
-                visibilityKey: buildComponentVisibilityKey(
-                    'vllm-hust',
-                    hustDisplayVersion,
-                    hustCommit,
-                    engineSource.ref
-                ),
-            });
-        }
-
-        const ascendHustVersion = hasRenderablePackageVersion(versions.backend)
-            ? versions.backend
-            : (canUseEngineVersionForPlugin ? engineVersion : '');
-        const ascendHustCommit = pluginSource.commit
-            || (canUseEngineVersionForPlugin ? getEntryGitCommit(entry) : '')
-            || extractCommitFromVersion(versions.backend)
-            || extractCommitFromVersion(engineVersion);
-        const ascendHustOverrideVersion = getHistoricalSameSpecVersionOverride(
-            dataSource,
-            'vllm-ascend-hust',
-            pluginSource.repository
-        );
-
-        const ascendHustDisplayVersion = resolveVersionDisplayValue(
-            ascendHustVersion,
-            ascendHustCommit,
-            pluginSource.ref,
-            {
-                overrideVersion: ascendHustOverrideVersion,
-                fallbackToRecordedRevision: hasHustPluginRepository,
-            }
-        );
-        if (ascendHustDisplayVersion) {
-            components.push({
-                label: 'vllm-ascend-hust',
-                version: ascendHustDisplayVersion,
-                rawVersion: ascendHustVersion,
-                overrideVersion: ascendHustOverrideVersion,
-                commit: ascendHustCommit,
-                ref: pluginSource.ref,
-                visibilityKey: buildComponentVisibilityKey(
-                    'vllm-ascend-hust',
-                    ascendHustDisplayVersion,
-                    ascendHustCommit,
-                    pluginSource.ref
-                ),
-            });
-        }
-
-        if (components.length) {
-            return components;
-        }
-
-        const isOfficialAscendStack = engineName === 'vllm'
-            && (
-                githubRepository.includes('vllm-ascend')
-                || pluginRepository.includes('vllm-ascend')
-                || dataSource.includes('vllm-ascend')
+        if (isHustStack) {
+            const hustVersion = hasRenderablePackageVersion(versions.core)
+                ? versions.core
+                : (canUseEngineVersionForHust ? engineVersion : '');
+            const hustCommit = engineSource.commit
+                || (canUseEngineVersionForHust ? getEntryGitCommit(entry) : '')
+                || extractCommitFromVersion(versions.core)
+                || extractCommitFromVersion(engineVersion);
+            const hustOverrideVersion = getHistoricalSameSpecVersionOverride(
+                dataSource,
+                'vllm-hust',
+                engineSource.repository
             );
+
+            const hustDisplayVersion = resolveVersionDisplayValue(
+                hustVersion,
+                hustCommit,
+                engineSource.ref,
+                {
+                    overrideVersion: hustOverrideVersion,
+                    fallbackToRecordedRevision: hasHustEngineRepository,
+                    missingValue: engineName === 'vllm-hust' && hasHustPluginRepository ? 'unrecorded' : '',
+                }
+            );
+            if (hustDisplayVersion) {
+                components.push({
+                    label: 'vllm-hust',
+                    version: hustDisplayVersion,
+                    rawVersion: hustVersion,
+                    overrideVersion: hustOverrideVersion,
+                    commit: hustCommit,
+                    ref: engineSource.ref,
+                    visibilityKey: buildComponentVisibilityKey(
+                        'vllm-hust',
+                        hustDisplayVersion,
+                        hustCommit,
+                        engineSource.ref
+                    ),
+                });
+            }
+
+            const ascendHustVersion = hasRenderablePackageVersion(versions.backend)
+                ? versions.backend
+                : (canUseEngineVersionForPlugin ? engineVersion : '');
+            const ascendHustCommit = pluginSource.commit
+                || (canUseEngineVersionForPlugin ? getEntryGitCommit(entry) : '')
+                || extractCommitFromVersion(versions.backend)
+                || extractCommitFromVersion(engineVersion);
+            const ascendHustOverrideVersion = getHistoricalSameSpecVersionOverride(
+                dataSource,
+                'vllm-ascend-hust',
+                pluginSource.repository
+            );
+
+            const ascendHustDisplayVersion = resolveVersionDisplayValue(
+                ascendHustVersion,
+                ascendHustCommit,
+                pluginSource.ref,
+                {
+                    overrideVersion: ascendHustOverrideVersion,
+                    fallbackToRecordedRevision: hasHustPluginRepository,
+                }
+            );
+            if (ascendHustDisplayVersion) {
+                components.push({
+                    label: 'vllm-ascend-hust',
+                    version: ascendHustDisplayVersion,
+                    rawVersion: ascendHustVersion,
+                    overrideVersion: ascendHustOverrideVersion,
+                    commit: ascendHustCommit,
+                    ref: pluginSource.ref,
+                    visibilityKey: buildComponentVisibilityKey(
+                        'vllm-ascend-hust',
+                        ascendHustDisplayVersion,
+                        ascendHustCommit,
+                        pluginSource.ref
+                    ),
+                });
+            }
+
+            if (components.length) {
+                return components;
+            }
+        }
+
         const officialVersion = formatComponentVersion(engineVersion || metadata.github_ref || '', '', { includeCommit: false });
         if (officialVersion) {
             components.push({

--- a/index.html
+++ b/index.html
@@ -2369,6 +2369,6 @@
     <script src="./assets/workstation-embed.js"></script>
 
     <!-- Leaderboard Script: bump ?v whenever leaderboard.js changes to bust browser/GitHub Pages caches -->
-  <script src="./assets/leaderboard.js?v=leaderboard-sort-pagination-version-contract-20260527"></script>
+  <script src="./assets/leaderboard.js?v=official-upstream-label-fix-20260531"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- keep official Ascend baseline rows labeled as `vllm` / `vllm-ascend` in leaderboard version summaries
- only infer `vllm-hust` / `vllm-ascend-hust` labels for entries that actually come from the HUST stack
- bump the leaderboard script cache key so the live site can pick up the frontend fix immediately

## Root cause
The official baseline data in benchmark snapshots is already correct. The website frontend mis-labeled some official rows because `assets/leaderboard.js` inferred HUST labels from `versions.core` and `versions.backend` alone, even when the entry engine and provenance clearly pointed to upstream `vllm` and `vllm-ascend`.

## Validation
- editor diagnostics: no errors in `assets/leaderboard.js` and `index.html`
- targeted smoke check with real snapshot rows confirmed official entries resolve to `vllm` / `vllm-ascend`
- targeted smoke check with HUST same-spec rows confirmed they still resolve to `vllm-hust` / `vllm-ascend-hust`
