### PR TITLE
fix(loader): make GitHub the first-priority leaderboard data source

### DIFF
--- a/assets/hf-data-loader.js
+++ b/assets/hf-data-loader.js
@@ -34,8 +34,8 @@ const HF_CONFIG = {
         'https://huggingface.co'
     ],
 
-    // 数据源优先级：hf -> github -> local
-    sources: ['hf', 'github', 'local'],
+    // 数据源优先级：github -> hf -> local
+    sources: ['github', 'hf', 'local'],
 
     // GitHub 仓库配置（用于不依赖 HF 的数据发布方式）
     github: {


### PR DESCRIPTION
## Summary

Change the default leaderboard data-source priority from HF-first to GitHub-first.

## Background

The leaderboard data loader (`assets/hf-data-loader.js`) currently tries
sources in this order by default:

```js
sources: ['hf', 'github', 'local']
```

This means the website waits on the Hugging Face mirror (or
`hf-mirror.com`) before falling back to the GitHub raw URL, even though
the GitHub raw URL is the canonical source where the publish pipeline
(`run_org_member_benchmarks.py` → `publish-website`) writes the
snapshots. The HF mirror is a downstream consumer and can lag behind
the source, plus it adds two extra HTTP hops and another failure domain.

## Change

Update `HF_CONFIG.sources` to put GitHub first:

```js
// data source priority: github -> hf -> local
sources: ['github', 'hf', 'local']
```

After this change the loader:

1. Tries `raw.githubusercontent.com/vLLM-HUST/vllm-hust-benchmark/main/leaderboard-data/snapshots/` first.
2. Falls back to the HF mirror (`intellistream/llm-engine-benchmark-results`) if GitHub fails.
3. Falls back to the bundled `./data/` files (used as a last-resort safety net).

The `?dataSource=github|hf|local` URL override is unchanged for debugging.

## Scope

This PR contains **only** the source-priority change. No other loader
behaviour, no schema changes, no rebuild of the bundled data files.

## Verification

- `git diff` shows a single two-line change in `assets/hf-data-loader.js`.
- The change is on the most recent remote `main` (`4cd899b`).
- Loader still validates the result with `assertUsableLeaderboardPayload`
  and writes the session cache, so behavior on success and on source
  failure is preserved.

## Note for operators

After merging, `https://vllm-hust.sage.org.ai/` will load data from
the GitHub raw URL first. The benchmark-repo snapshot
(`leaderboard-data/snapshots/`) becomes the canonical source, so
ensure the publish pipeline keeps it in sync (it already does, via
`publish-website` in `run_org_member_benchmarks.py`).

Assisted-by: Qoder Agent