### PR TITLE
fix(loader): make GitHub the first-priority leaderboard data source

### DIFF
--- a/assets/hf-data-loader.js
+++ b/assets/hf-data-loader.js
@@ -34,8 +34,8 @@ const HF_CONFIG = {
         'https://huggingface.co'
     ],
 
-    // 数据源优先级：hf -> github -> local
-    sources: ['hf', 'github', 'local'],
+    // 数据源优先级：github -> hf -> local
+    sources: ['github', 'hf', 'local'],
 
     // GitHub 仓库配置（用于不依赖 HF 的数据发布方式）
     github: {


### PR DESCRIPTION
Re-proposes the intent of #66 in a minimal, safe form. #66 was closed because its branch was based on pre-#68 main, so the single commit also carried the reverse of every test contract that #68 just merged (CACHE_KEY v2→v3, renderEngineSummaryCard revert, same_spec_hashes_match spec_id fallback restore, engine_version_prefix tightening, etc.). Merging #66 as-is would have re-introduced the 6 unit test failures.

This PR is based on current main (112697d) and its only diff is:

```diff
-    // 数据源优先级：hf -> github -> local
-    sources: ['hf', 'github', 'local'],
+    // 数据源优先级：github -> hf -> local
+    sources: ['github', 'hf', 'local'],
```

The `?dataSource=` URL override in getSourcePriority() is unchanged, so users can still force a specific source for debugging.

Verification:
- `pre-commit run --files assets/hf-data-loader.js`: all relevant hooks pass (trim trailing whitespace, end-of-file fixer, detect-secrets, etc.)
- `pytest`: 32/32 passing locally

AI assistance was used (Qoder Agent authored both #66 and the prior analysis). Human review still required before merge.