### PR TITLE
fix(schema): allow null for ttft_ms, throughput_tps, error_rate

### DIFF
--- a/data/schemas/leaderboard_v1.schema.json
+++ b/data/schemas/leaderboard_v1.schema.json
@@ -236,7 +236,7 @@
           ],
           "properties": {
             "ttft_ms": {
-              "type": "number",
+              "type": ["number", "null"],
               "minimum": 0
             },
             "tbt_ms": {
@@ -254,7 +254,7 @@
               "minimum": 0
             },
             "throughput_tps": {
-              "type": "number",
+              "type": ["number", "null"],
               "minimum": 0
             },
             "peak_mem_mb": {
@@ -265,7 +265,7 @@
               "minimum": 0
             },
             "error_rate": {
-              "type": "number",
+              "type": ["number", "null"],
               "minimum": 0,
               "maximum": 1
             },


### PR DESCRIPTION
## Changes

Update leaderboard schema to allow `null` for metrics that may not be applicable depending on `benchmark_type`:

| Metric | Allow null | Reason |
|--------|-----------|--------|
| `ttft_ms` | ✅ | Not measured for throughput benchmarks |
| `throughput_tps` | ✅ | Not measured for latency benchmarks |
| `error_rate` | ✅ | Not applicable for latency benchmarks |
| `tbt_ms` | ✅ *(unchanged)* | Already allowed null |

This is consistent with `tbt_ms` which already had `type: ["number", "null"]`.

Required by vllm-hust-benchmark#35 to regenerate snapshots with suppressed inapplicable metrics.

Co-Authored-By: Claude <noreply@anthropic.com>