### PR TITLE
ui: merge repeated leaderboard version cells

### DIFF
--- a/assets/leaderboard.css
+++ b/assets/leaderboard.css
@@ -987,22 +987,22 @@
 
 /* Sticky First Column */
 .leaderboard-table th:first-child,
-.leaderboard-table td:first-child {
+.leaderboard-table td.version-table-cell {
     position: sticky;
     left: 0;
     z-index: 5;
     background: inherit;
 }
 
-.leaderboard-table tbody tr:nth-child(even) td:first-child {
+.leaderboard-table tbody tr:nth-child(even) td.version-table-cell {
     background: #f7fafc;
 }
 
-.leaderboard-table tbody tr:nth-child(odd) td:first-child {
+.leaderboard-table tbody tr:nth-child(odd) td.version-table-cell {
     background: white;
 }
 
-.leaderboard-table tbody tr:hover td:first-child {
+.leaderboard-table tbody tr:hover td.version-table-cell {
     background: #edf2f7;
 }
 
@@ -1012,10 +1012,7 @@
     vertical-align: top;
 }
 
-.leaderboard-table td:nth-child(4),
-.leaderboard-table td:nth-child(5),
-.leaderboard-table td:nth-child(6),
-.leaderboard-table td:nth-child(7) {
+.leaderboard-table td.metric-column {
     min-width: 122px;
 }
 

--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1334,6 +1334,10 @@
         return formatEntryVersion(entry, { display: true });
     }
 
+    function getTableVersionRowSpanKey(entry) {
+        return getTableVersionVisibilityKey(entry);
+    }
+
     function formatOverviewComponentVersion(component) {
         if (!component?.label) {
             return '';
@@ -2807,20 +2811,25 @@
         // Render rows
         const showVersionAllParam = typeof window !== 'undefined'
             && new URLSearchParams(window.location.search).get('showVersionAll') === '1';
+        const showVersionForEveryRow = showVersionAllParam
+            || Boolean(sortState.column)
+            || filters.version !== 'all';
+        const rowSpanInfo = buildVersionRowSpanInfo(pageRows, {
+            showVersionAll: showVersionAllParam,
+            forceEveryRow: showVersionForEveryRow,
+            expandedRows: state.expandedRows,
+        });
+
         tbody.innerHTML = pageRows.map((entry, index) => {
             // Only the first item of the first page (in default sort) carries the "Latest" badge
             const isLatest = !sortState.column && pagination.page === 1 && index === 0;
             const isExpanded = state.expandedRows.has(entry.entry_id);
-            const currentVersion = getTableVersionVisibilityKey(entry);
-            const prevVersion = index > 0 ? getTableVersionVisibilityKey(pageRows[index - 1]) : null;
-            // Force show-version for every row when column sort is active (order is no longer version-grouped)
-            const showVersionForEveryRow = showVersionAllParam || Boolean(sortState.column);
-            const showVersion = showVersionForEveryRow || index === 0 || currentVersion !== prevVersion;
+            const rowSpan = rowSpanInfo.get(entry.entry_id) || { showVersion: true, span: 1 };
             const isSparse = comparisonView.incompleteKeys.has(createCompareScopeKey(entry));
 
             return `
-                ${renderDataRow(entry, isLatest, isExpanded, showVersion, isSparse)}
-                ${renderDetailsRow(entry, isExpanded)}
+                ${renderDataRow(entry, isLatest, isExpanded, rowSpan.showVersion, isSparse, rowSpan.span)}
+                ${isExpanded ? renderDetailsRow(entry, isExpanded) : ''}
             `;
         }).join('');
 
@@ -2832,6 +2841,48 @@
 
         // Attach event listeners for buttons
         attachRowEventListeners();
+    }
+
+    function buildVersionRowSpanInfo(entries, options = {}) {
+        const showVersionForEveryRow = Boolean(options.showVersionAll || options.forceEveryRow);
+        const expandedRows = options.expandedRows instanceof Set ? options.expandedRows : new Set();
+        const info = new Map();
+        let index = 0;
+
+        while (index < entries.length) {
+            const entry = entries[index];
+            const key = getTableVersionRowSpanKey(entry);
+            let span = 1;
+
+            if (!showVersionForEveryRow) {
+                while (
+                    index + span < entries.length
+                    && getTableVersionRowSpanKey(entries[index + span]) === key
+                ) {
+                    span += 1;
+                }
+            }
+
+            const groupHasExpandedRow = entries
+                .slice(index, index + span)
+                .some((groupEntry) => expandedRows.has(groupEntry.entry_id));
+
+            if (groupHasExpandedRow) {
+                for (let offset = 0; offset < span; offset += 1) {
+                    info.set(entries[index + offset].entry_id, { showVersion: true, span: 1 });
+                }
+                index += span;
+                continue;
+            }
+
+            info.set(entry.entry_id, { showVersion: true, span });
+            for (let offset = 1; offset < span; offset += 1) {
+                info.set(entries[index + offset].entry_id, { showVersion: false, span: 0 });
+            }
+            index += span;
+        }
+
+        return info;
     }
 
     function renderDataStats(tabTotal, rawFilteredTotal, visibleTotal, mergedTotal, comparisonView) {
@@ -3789,7 +3840,7 @@
     }
 
     // Render data row
-    function renderDataRow(entry, isLatest, isExpanded, showVersion, isSparse) {
+    function renderDataRow(entry, isLatest, isExpanded, showVersion, isSparse, versionRowSpan = 1) {
         const m = entry.metrics;
         const trends = entry.trends || {};
         const dateLabel = getEntryDateLabel(entry);
@@ -3807,27 +3858,30 @@
         // 生成配置描述（芯片数/节点数）
         const configText = getConfigText(entry);
         const workloadText = getWorkloadLabel(getWorkloadId(entry));
-
-        return `
-            <tr data-entry-id="${entry.entry_id}" class="${isSparse ? 'is-sparse' : ''}">
-                <td>
+        const versionCellHtml = showVersion ? `
+                <td class="version-table-cell" rowspan="${Math.max(1, versionRowSpan)}">
                     <div class="version-cell">
-                        ${showVersion ? `<div class="version-main version-main--aligned">${versionMainText}</div>` : ''}
-                        ${showVersion ? provenanceSummary : ''}
-                        ${showVersion ? `<small class="version-setting-summary">${settingSummary}</small>` : ''}
-                        ${showVersion && buildCount > 1 ? `<small class="version-merge-hint">${t('bestFourth')}</small>` : ''}
-                        ${showVersion && isSparse ? `<small class="version-merge-hint sparse">${t('sparseGroup')}</small>` : ''}
-                        ${(showVersion && (isLatest || entry.isBaseline))
+                        <div class="version-main version-main--aligned">${versionMainText}</div>
+                        ${provenanceSummary}
+                        <small class="version-setting-summary">${settingSummary}</small>
+                        ${buildCount > 1 ? `<small class="version-merge-hint">${t('bestFourth')}</small>` : ''}
+                        ${isSparse ? `<small class="version-merge-hint sparse">${t('sparseGroup')}</small>` : ''}
+                        ${(isLatest || entry.isBaseline)
                             ? `<div class="version-badges">${isLatest ? `<span class="version-badge">${t('latest')}</span>` : ''}${entry.isBaseline ? `<span class="version-badge baseline">${t('baseline')}</span>` : ''}</div>`
                             : ''}
                     </div>
                 </td>
+            ` : '';
+
+        return `
+            <tr data-entry-id="${entry.entry_id}" class="${isSparse ? 'is-sparse' : ''}">
+                ${versionCellHtml}
                 <td class="config-cell">${workloadText}</td>
                 <td class="config-cell">${configText}</td>
-                <td>${renderMetricCell(m.ttft_ms, trends.ttft_ms, false, false, entry.isBaseline)}</td>
-                <td>${renderMetricCell(m.tbt_ms, trends.tbt_ms, false, false, entry.isBaseline)}</td>
-                <td>${renderMetricCell(m.throughput_tps, trends.throughput_tps, true, false, entry.isBaseline)}</td>
-                <td>${renderMetricCell(m.error_rate, trends.error_rate, false, true, entry.isBaseline)}</td>
+                <td class="metric-column">${renderMetricCell(m.ttft_ms, trends.ttft_ms, false, false, entry.isBaseline)}</td>
+                <td class="metric-column">${renderMetricCell(m.tbt_ms, trends.tbt_ms, false, false, entry.isBaseline)}</td>
+                <td class="metric-column">${renderMetricCell(m.throughput_tps, trends.throughput_tps, true, false, entry.isBaseline)}</td>
+                <td class="metric-column">${renderMetricCell(m.error_rate, trends.error_rate, false, true, entry.isBaseline)}</td>
                 <td class="action-cell">
                     <button class="btn-details" data-entry-id="${entry.entry_id}">
                         ${isExpanded ? t('hide') : (buildCount > 1 ? t('fourthVersion') : t('details'))}

--- a/data/README.md
+++ b/data/README.md
@@ -10,8 +10,8 @@
 - HF dataset: the secondary distribution surface for the website. It should publish the same
   `leaderboard_single.json`, `leaderboard_multi.json`, `leaderboard_compare.json`, and
   `last_updated.json` files from the benchmark snapshot set.
-- Retired baseline data: `vllm 0.11.0` / `v0110` rows must not appear in the website mirror.
-  The public baseline is `vllm 0.18.0` plus the matching `vllm-ascend 0.18.0` snapshot set.
+- Retired baseline data: `vllm 0.11.0` / `v0110` rows must not appear in the website mirror. The
+  public baseline is `vllm 0.18.0` plus the matching `vllm-ascend 0.18.0` snapshot set.
 - Website `data/`: a compatibility cache for checked-in snapshots and offline development. It should
   not be edited by hand and should not ingest raw compare directory layouts.
 

--- a/docs/LEADERBOARD_UI_INVARIANTS.md
+++ b/docs/LEADERBOARD_UI_INVARIANTS.md
@@ -5,23 +5,22 @@ This file records non-negotiable leaderboard display rules. Keep it in sync with
 
 ## Overview Cards
 
-- The top overview cards must never show averages across workloads, precision
-  modes, models, hardware, or settings.
+- The top overview cards must never show averages across workloads, precision modes, models,
+  hardware, or settings.
 - Each overview card metric must come from one concrete benchmark row.
-- When multiple complete compare scopes are visible, choose exactly one scope:
-  the scope where the best visible `vllm-hust` row has the largest throughput
-  improvement over the matching official `vllm` `0.18.0` row.
-- The selected scope must stay aligned across both cards: same workload, model,
-  hardware, chip count, node count, precision, and setting signature.
-- Row counts may describe coverage, but metric values must remain sample values
-  from the selected scope.
+- When multiple complete compare scopes are visible, choose exactly one scope: the scope where the
+  best visible `vllm-hust` row has the largest throughput improvement over the matching official
+  `vllm` `0.18.0` row.
+- The selected scope must stay aligned across both cards: same workload, model, hardware, chip
+  count, node count, precision, and setting signature.
+- Row counts may describe coverage, but metric values must remain sample values from the selected
+  scope.
 
 ## Hardware And Precision Labels
 
-- Hardware and precision labels must come from the benchmark artifact produced
-  by the actual run.
+- Hardware and precision labels must come from the benchmark artifact produced by the actual run.
 - The website must not hard-code hardware labels such as `910B2` or `910B3`.
-- The benchmark publication pipeline must reject public records whose artifact
-  hardware or precision disagrees with the same-spec payload.
-- Do not infer hardware from a file name, run id, branch name, or screenshot.
-  Use same-spec/runtime metadata and validate before publishing.
+- The benchmark publication pipeline must reject public records whose artifact hardware or precision
+  disagrees with the same-spec payload.
+- Do not infer hardware from a file name, run id, branch name, or screenshot. Use same-spec/runtime
+  metadata and validate before publishing.

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -10,7 +10,7 @@
   <link rel="canonical" href="https://vllm-hust.sage.org.ai/leaderboard.html" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=multi-page-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-overview-sample-20260701-2" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-version-rowspan-20260701" />
 </head>
 
 <body data-page="leaderboard">
@@ -170,7 +170,7 @@
   <script src="./assets/site.js?v=multi-page-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v6-20260701"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-overview-sample-20260701-2"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-version-rowspan-20260701"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -96,7 +96,10 @@ def test_hf_loader_rejects_incomplete_compare_snapshots() -> None:
     assert "sources: ['github', 'hf', 'local']" in text
     assert "llm_engine_hf_leaderboard_cache_v6" in text
     assert "const LOCAL_DATA_CACHE_BUST = 'leaderboard-data-20260701-3';" in text
-    assert "const url = `${HF_CONFIG.localPath}${filename}${separator}v=${LOCAL_DATA_CACHE_BUST}`;" in text
+    assert (
+        "const url = `${HF_CONFIG.localPath}${filename}${separator}v=${LOCAL_DATA_CACHE_BUST}`;"
+        in text
+    )
     assert "function clearCache()" in text
     assert "Ignoring unusable session cache" in text
 
@@ -106,10 +109,18 @@ def test_leaderboard_data_excludes_retired_v0110_baselines() -> None:
     single = json.loads((root / "data" / "leaderboard_single.json").read_text())
 
     ids = {entry["entry_id"] for entry in single}
-    assert "36551323-7a0b-4832-b14b-98bf4edfd271" not in ids  # vllm-hust #41, retired v0110 baseline
-    assert "fd20fab5-1733-4bf0-b79b-9c41d09b53db" not in ids  # vllm-hust #45, retired v0110 baseline
-    assert "e851c419-0115-440d-9304-2175859494b8" not in ids  # vllm-hust #46, retired v0110 baseline
-    assert "b78295f6-3ad4-4a56-9c85-175165e5d347" not in ids  # vllm-hust #49, retired v0110 baseline
+    assert (
+        "36551323-7a0b-4832-b14b-98bf4edfd271" not in ids
+    )  # vllm-hust #41, retired v0110 baseline
+    assert (
+        "fd20fab5-1733-4bf0-b79b-9c41d09b53db" not in ids
+    )  # vllm-hust #45, retired v0110 baseline
+    assert (
+        "e851c419-0115-440d-9304-2175859494b8" not in ids
+    )  # vllm-hust #46, retired v0110 baseline
+    assert (
+        "b78295f6-3ad4-4a56-9c85-175165e5d347" not in ids
+    )  # vllm-hust #49, retired v0110 baseline
 
     for entry in single:
         same_spec = entry.get("same_spec") or {}
@@ -143,9 +154,9 @@ def test_leaderboard_data_is_benchmark_snapshot_mirror() -> None:
 
 def test_leaderboard_sync_workflow_uses_snapshot_sync_script() -> None:
     root = Path(__file__).resolve().parents[1]
-    workflow = (
-        root / ".github" / "workflows" / "sync-leaderboard-data.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (root / ".github" / "workflows" / "sync-leaderboard-data.yml").read_text(
+        encoding="utf-8"
+    )
     script = (root / "scripts" / "sync_leaderboard_snapshots.py").read_text(
         encoding="utf-8"
     )
@@ -175,7 +186,7 @@ def test_homepage_exposes_multi_page_navigation_and_workstation() -> None:
     assert 'href="./contributors.html"' in text
     assert 'id="workstation-section"' in text
     assert 'id="workstation-embed-frame"' in text
-    assert './assets/workstation-embed.js?v=' in text
+    assert "./assets/workstation-embed.js?v=" in text
 
 
 def test_validation_dependencies_have_single_source_of_truth() -> None:
@@ -211,13 +222,19 @@ def test_engine_summary_cards_use_composite_version_components() -> None:
     assert "function getOverviewSummaryChipText(summary)" in text
     assert "function getOverviewSummaryVersionText(summary)" in text
     assert "return resolvedVersion;" in text
-    assert "overviewComponents: buildTableVersionComponents(bestEntry || coverageBestEntry)" in text
+    assert (
+        "overviewComponents: buildTableVersionComponents(bestEntry || coverageBestEntry)"
+        in text
+    )
     assert "const chipText = getOverviewSummaryChipText(summary);" in text
     assert "const versionText = getOverviewSummaryVersionText(summary);" in text
     assert "const bestVisibleRunText =" in text
     assert "function selectOverviewRepresentativeGroup(comparisonView)" in text
     assert "const representativeGroup = overviewScopeLocked" in text
-    assert "representativeGroup?.summaryLabel || getOverviewAggregateScopeText(comparisonView)" in text
+    assert (
+        "representativeGroup?.summaryLabel || getOverviewAggregateScopeText(comparisonView)"
+        in text
+    )
     assert "getBestEntryForEngine(group.entries, 'vllm-hust')" in text
     assert "function getOfficialVllmBaselineEntry(entries)" in text
     assert "function getThroughputImprovementScore(currentEntry, baselineEntry)" in text
@@ -237,13 +254,8 @@ def test_engine_summary_cards_use_composite_version_components() -> None:
     assert '<div class="engine-summary-meta">' in text
     assert '<span class="engine-summary-version-label">${versionPrefix}</span>' in text
     assert '<span class="engine-summary-version-value">${versionText}</span>' in text
-    assert (
-        '<span class="engine-summary-footer-label">${footerLabel}:</span>'
-        in text
-    )
-    assert (
-        '<span class="engine-summary-footer-value">${footerValue}</span>' in text
-    )
+    assert '<span class="engine-summary-footer-label">${footerLabel}:</span>' in text
+    assert '<span class="engine-summary-footer-value">${footerValue}</span>' in text
     metrics_index = text.index('<div class="engine-summary-metrics">')
     meta_index = text.index('<div class="engine-summary-meta">')
     version_index = text.index('<div class="engine-summary-version">')
@@ -269,7 +281,10 @@ def test_leaderboard_overview_compare_scope_includes_precision() -> None:
     )
     assert "activeGroups," in text
     assert "function getSingleCompleteOverviewGroup(comparisonView)" in text
-    assert "const precisions = getUniqueValues(entries, (entry) => entry?.model?.precision);" in text
+    assert (
+        "const precisions = getUniqueValues(entries, (entry) => entry?.model?.precision);"
+        in text
+    )
     assert (
         "const precisionText = precisions.length === 1 ? precisions[0] : `${precisions.length} ${t('precision')}`;"
         in text
@@ -282,15 +297,19 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     js_text = (root / "assets" / "leaderboard.js").read_text(encoding="utf-8")
     css_text = (root / "assets" / "leaderboard.css").read_text(encoding="utf-8")
 
-    assert "https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js" in html_text
+    assert (
+        "https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js" in html_text
+    )
     assert 'id="leaderboard-trend-panel"' in html_text
     assert 'id="leaderboard-trend-chart"' in html_text
     assert 'data-trend-metric="throughput_tps"' in html_text
     assert "leaderboard-cache-v6-20260701" in html_text
-    assert "leaderboard-overview-sample-20260701-2" in html_text
+    assert "leaderboard-version-rowspan-20260701" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert "const model = getEntryModelCanonicalId(entry)" in js_text
-    assert "const hardware = entry?.hardware?.chip_model || 'unknown-hardware';" in js_text
+    assert (
+        "const hardware = entry?.hardware?.chip_model || 'unknown-hardware';" in js_text
+    )
     assert (
         "return [workload, model, hardware, chipCount, nodeCount, precision, settingSignature].join('|');"
         in js_text
@@ -360,7 +379,7 @@ def test_leaderboard_version_display_contract_is_documented_and_split() -> None:
     )
 
     render_data_row_start = text.index(
-        "function renderDataRow(entry, isLatest, isExpanded, showVersion, isSparse) {"
+        "function renderDataRow(entry, isLatest, isExpanded, showVersion, isSparse, versionRowSpan = 1) {"
     )
     render_details_row_start = text.index(
         "function renderDetailsRow(entry, isExpanded) {"
@@ -371,8 +390,22 @@ def test_leaderboard_version_display_contract_is_documented_and_split() -> None:
         in render_data_row_text
     )
     assert "const versionMainText = tableVersionSummary" in render_data_row_text
+    assert 'rowspan="${Math.max(1, versionRowSpan)}"' in render_data_row_text
     assert "getEntryDetailedVersionText" not in render_data_row_text
     assert "formatDetailedVersion" not in render_data_row_text
+    assert "function getTableVersionRowSpanKey(entry)" in text
+    assert "return getTableVersionVisibilityKey(entry);" in text
+    assert "const key = getTableVersionRowSpanKey(entry);" in text
+    assert (
+        "const showVersionForEveryRow = showVersionAllParam\n"
+        "            || Boolean(sortState.column)\n"
+        "            || filters.version !== 'all';" in text
+    )
+    assert "forceEveryRow: showVersionForEveryRow," in text
+    assert (
+        "${renderDataRow(entry, isLatest, isExpanded, rowSpan.showVersion, isSparse, rowSpan.span)}"
+        in text
+    )
 
     render_versions_start = text.index("function renderVersionsSection(entry) {")
     render_build_start = text.index("function renderBuildVariantsSection(entry) {")
@@ -463,6 +496,4 @@ def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> No
     )
     assert "'./data/core_contributors.json'" in text
     assert "async function fetchPayload()" in text
-    assert (
-        "console.warn('[contributors] source failed', source, err);" in text
-    )
+    assert "console.warn('[contributors] source failed', source, err);" in text


### PR DESCRIPTION
 ## Summary

  Merge repeated leaderboard version cells in the main benchmark table so consecutive rows for the same engine/version render as one shared
  version cell instead of leaving blank first-column cells.

  This improves readability for grouped workload rows, especially when one engine/version has multiple workload entries in the current
  comparison scope.

  ## Repository Scope

  - [ ] `vllm-hust`
  - [ ] `vllm-ascend-hust`
  - [ ] `ascend-runtime-manager`
  - [ ] `vllm-hust-dev-hub`
  - [ ] `vllm-hust-benchmark`
  - [x] `vllm-hust-website`
  - [ ] `vllm-hust-workstation`
  - [ ] `vllm-hust-docs`
  - [ ] `EvoScientist`
  - [ ] other

  ## Validation

  - `node --check assets/leaderboard.js`
  - `git diff --check`

  ## Risks

  - Low UI risk. The change only affects leaderboard table rendering.
  - Row merging is disabled while sorting is active and falls back to per-row version cells when a grouped row is expanded, to avoid table
  layout issues with details rows.
  - No benchmark, deployment, or hardware workflows were run.

  ## Checklist

  - [x] I removed or redacted secrets, tokens, and private endpoints.
  - [ ] I updated docs if user-facing behavior changed.
  - [x] I noted the tests I ran, or clearly stated what I could not run.