### PR TITLE
[codex] Limit default trend chart to mainline runs

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -229,7 +229,7 @@
             overviewCompareSnapshotNote: 'Hero deltas use the matched compare snapshot. Cards below show the highlighted visible sample for each engine.',
             trendLabel: 'Version Trend',
             trendTitle: 'Performance trend',
-            trendSubtitle: 'Baseline first, then visible versions in submission order. The default all-workloads trend shows online serving workloads; select a workload to inspect throughput or latency runs.',
+            trendSubtitle: 'Baseline first, then mainline online serving versions. Select a workload to inspect the full PR and historical run sequence.',
             trendMetricThroughput: 'Tokens/s',
             trendMetricTTFT: 'TTFT',
             trendMetricTBT: 'TBT',
@@ -435,7 +435,7 @@
             overviewCompareSnapshotNote: '顶部 Hero 的差距值来自当前命中的 compare snapshot；下方卡片展示每个引擎当前高亮样本。',
             trendLabel: '版本趋势',
             trendTitle: '性能趋势',
-            trendSubtitle: '横轴从基线开始，再按提交时间展示当前可见版本；默认全部视图展示 online serving workload，throughput/latency 请切到具体 workload 查看。',
+            trendSubtitle: '横轴从基线开始，默认全部视图只展示 mainline online serving 版本；切到具体 workload 可查看完整 PR 与历史运行序列。',
             trendMetricThroughput: '吞吐',
             trendMetricTTFT: 'TTFT',
             trendMetricTBT: 'TBT',
@@ -1833,12 +1833,24 @@
         return String(getWorkloadId(entry) || '').endsWith('-online');
     }
 
+    function isMainlineTrendEntry(entry) {
+        if (isTrendBaselineEntry(entry)) {
+            return true;
+        }
+
+        const ref = String(entry?.metadata?.github_ref || '').trim().toLowerCase();
+        return ref === 'main' || ref === 'main-current' || ref.startsWith('main-');
+    }
+
     function getPerformanceTrendEntries(entries, selectedWorkload) {
         return entries.filter((entry) => {
             if (shouldExcludeFromTrends(entry)) {
                 return false;
             }
-            return selectedWorkload === 'all' ? isOnlineServingWorkload(entry) : true;
+            if (selectedWorkload !== 'all') {
+                return true;
+            }
+            return isOnlineServingWorkload(entry) && isMainlineTrendEntry(entry);
         });
     }
 

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="./assets/brand/vllm-hust-icon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=public-copy-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260705-trendsort1" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260705-mainline1" />
 </head>
 
 <body data-page="leaderboard">
@@ -200,7 +200,7 @@
   <script src="./assets/site.js?v=public-copy-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v7-20260702"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-public-20260705-trendsort1"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-public-20260705-mainline1"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -415,7 +415,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert 'data-trend-axis="log"' in html_text
     assert 'data-trend-axis="linear"' in html_text
     assert "leaderboard-cache-v7-20260702" in html_text
-    assert "leaderboard-public-20260705-trendsort1" in html_text
+    assert "leaderboard-public-20260705-mainline1" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert (
         "const sortValue = baseline ? Number.NEGATIVE_INFINITY : (timestamp || 0);"
@@ -438,7 +438,9 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
         "return [workload, model, hardware, chipCount, nodeCount, precision, quantization, settingSignature].join('|');"
         in js_text
     )
-    assert "默认全部视图展示 online serving workload" in js_text
+    assert "默认全部视图只展示 mainline online serving 版本" in js_text
+    assert "function isMainlineTrendEntry(entry)" in js_text
+    assert "isOnlineServingWorkload(entry) && isMainlineTrendEntry(entry)" in js_text
     assert "function renderPerformanceTrendChart(entries)" in js_text
     assert "new Chart(canvas" in js_text
     assert "pointDetails" in js_text
@@ -465,10 +467,8 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "min: yAxisBounds.min" in js_text
     assert "function isOnlineServingWorkload(entry)" in js_text
     assert "function getPerformanceTrendEntries(entries, selectedWorkload)" in js_text
-    assert (
-        "return selectedWorkload === 'all' ? isOnlineServingWorkload(entry) : true;"
-        in js_text
-    )
+    assert "if (selectedWorkload !== 'all')" in js_text
+    assert "return true;" in js_text
     assert (
         "renderPerformanceTrendChart(getPerformanceTrendEntries(sortedFiltered, filters.workload));"
         in js_text


### PR DESCRIPTION
## Summary
- Limit the default `all workloads` performance trend to baseline plus mainline online-serving runs (`main`, `main-current`, and `main-*`).
- Keep full PR / historical run visibility when a specific workload is selected.
- Update the trend subtitle and bump the leaderboard asset cache key.

## Why
The default overview was connecting PR validation branches and repeated historical run labels as if they were a single version progression. That made the chart look like it had unexplained up/down oscillations even when the active data had no missing points. The overview should be a stable mainline trend; detailed workload views remain available for PR-level investigation.

## Validation
- `python3 -m pytest tests/test_site_structure.py -q` (`29 passed`)
- `python3 data/validate_schema.py data/leaderboard_single.json data/leaderboard_multi.json`
- Data audit for the default all-workloads chart now yields 4 x-axis buckets, each with 6/6 online workloads: baseline, `main-current`, `main-7a63-d40e-gapfill`, and `main#2206`.
