### PR TITLE
fix: bump leaderboard asset cache token

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="./assets/brand/vllm-hust-icon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=public-copy-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260705-mainline1" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-trend-filters1" />
 </head>
 
 <body data-page="leaderboard">
@@ -200,7 +200,7 @@
   <script src="./assets/site.js?v=public-copy-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v7-20260702"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-public-20260705-mainline1"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-trend-filters1"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -446,7 +446,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert 'data-trend-axis="log"' in html_text
     assert 'data-trend-axis="linear"' in html_text
     assert "leaderboard-cache-v7-20260702" in html_text
-    assert "leaderboard-public-20260705-mainline1" in html_text
+    assert "leaderboard-public-20260706-trend-filters1" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert (
         "const sortValue = baseline ? Number.NEGATIVE_INFINITY : (timestamp || 0);"


### PR DESCRIPTION
## Summary
- bump the leaderboard JS asset query token so the deployed site stops serving cached pre-PR JavaScript
- update the structure test to expect the new cache token

## Validation
- python3 -m pytest tests/test_site_structure.py::test_leaderboard_renders_interactive_trend_chart -q