### PR TITLE
fix: include multi-chip online workloads in trend chart

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1834,7 +1834,7 @@
         return workload.endsWith('-online')
             || workload.endsWith('-throughput')
             || workload.endsWith('-latency')
-            || /-(throughput|latency)-\d+chip$/.test(workload);
+            || /-(online|throughput|latency)-\d+chip$/.test(workload);
     }
 
     function isMainlineTrendEntry(entry) {
@@ -1843,7 +1843,10 @@
         }
 
         const ref = String(entry?.metadata?.github_ref || '').trim().toLowerCase();
-        return ref === 'main' || ref === 'main-current' || ref.startsWith('main-');
+        return ref === 'main'
+            || ref === 'main-current'
+            || ref.startsWith('main-')
+            || ref.startsWith('current-main');
     }
 
     function getPerformanceTrendEntries(entries, selectedWorkload) {

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -475,6 +475,8 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "if (value === 'all')" in js_text
     assert "function isServingTrendWorkload(entry)" in js_text
     assert "workload.endsWith('-throughput')" in js_text
+    assert "/-(online|throughput|latency)-\\d+chip$/" in js_text
+    assert "ref.startsWith('current-main')" in js_text
     assert "isServingTrendWorkload(entry) && isMainlineTrendEntry(entry)" in js_text
     assert "function renderPerformanceTrendChart(entries)" in js_text
     assert "new Chart(canvas" in js_text


### PR DESCRIPTION
## Summary
- treat `*-online-2chip/4chip` workloads as serving trend workloads in the All trend view
- classify `current-main-*` benchmark rows as mainline trend entries
- keeps suspect/exclude-from-trends filtering unchanged

## Validation
- node --check assets/leaderboard.js
- python3 -m pytest tests/test_site_structure.py::test_leaderboard_renders_interactive_trend_chart -q
- local data audit: multi-chip All trend rows increase from only 2 sonnet baseline rows to 18 rows (10 baseline rows + 8 current-main rows)