### PR TITLE
fix: generalize trend workload filtering

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -1829,24 +1829,39 @@
         return Boolean(entry?.quality?.exclude_from_trends) || isSuspectEntry(entry);
     }
 
+    const SERVING_TREND_WORKLOAD_SUFFIXES = ['online', 'throughput', 'latency'];
+
+    function getServingTrendWorkloadBase(entry) {
+        return String(getWorkloadId(entry) || '').replace(/-\d+chip$/, '');
+    }
+
     function isServingTrendWorkload(entry) {
-        const workload = String(getWorkloadId(entry) || '');
-        return workload.endsWith('-online')
-            || workload.endsWith('-throughput')
-            || workload.endsWith('-latency')
-            || /-(online|throughput|latency)-\d+chip$/.test(workload);
+        const workload = getServingTrendWorkloadBase(entry);
+        return SERVING_TREND_WORKLOAD_SUFFIXES.some((suffix) => workload.endsWith(`-${suffix}`));
+    }
+
+    function getTrendRefTokens(entry) {
+        return String(entry?.metadata?.github_ref || '')
+            .trim()
+            .toLowerCase()
+            .split(/[^a-z0-9]+/)
+            .filter(Boolean);
+    }
+
+    function hasPullRequestMetadata(entry) {
+        const metadata = entry?.metadata || {};
+        return Boolean(metadata.github_pr_number || metadata.github_pr_url);
     }
 
     function isMainlineTrendEntry(entry) {
         if (isTrendBaselineEntry(entry)) {
             return true;
         }
+        if (hasPullRequestMetadata(entry)) {
+            return false;
+        }
 
-        const ref = String(entry?.metadata?.github_ref || '').trim().toLowerCase();
-        return ref === 'main'
-            || ref === 'main-current'
-            || ref.startsWith('main-')
-            || ref.startsWith('current-main');
+        return getTrendRefTokens(entry).includes('main');
     }
 
     function getPerformanceTrendEntries(entries, selectedWorkload) {

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="./assets/brand/vllm-hust-icon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=public-copy-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-multichip-trends1" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-generic-trends1" />
 </head>
 
 <body data-page="leaderboard">
@@ -200,7 +200,7 @@
   <script src="./assets/site.js?v=public-copy-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v7-20260702"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-multichip-trends1"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-generic-trends1"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -446,7 +446,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert 'data-trend-axis="log"' in html_text
     assert 'data-trend-axis="linear"' in html_text
     assert "leaderboard-cache-v7-20260702" in html_text
-    assert "leaderboard-public-20260706-multichip-trends1" in html_text
+    assert "leaderboard-public-20260706-generic-trends1" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert (
         "const sortValue = baseline ? Number.NEGATIVE_INFINITY : (timestamp || 0);"
@@ -474,9 +474,16 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "function getSelectOptionLabel(value, option, labelMapper = null)" in js_text
     assert "if (value === 'all')" in js_text
     assert "function isServingTrendWorkload(entry)" in js_text
-    assert "workload.endsWith('-throughput')" in js_text
-    assert "/-(online|throughput|latency)-\\d+chip$/" in js_text
-    assert "ref.startsWith('current-main')" in js_text
+    assert (
+        "const SERVING_TREND_WORKLOAD_SUFFIXES = ['online', 'throughput', 'latency'];"
+        in js_text
+    )
+    assert "function getServingTrendWorkloadBase(entry)" in js_text
+    assert "replace(/-\\d+chip$/, '')" in js_text
+    assert "function getTrendRefTokens(entry)" in js_text
+    assert "function hasPullRequestMetadata(entry)" in js_text
+    assert "getTrendRefTokens(entry).includes('main')" in js_text
+    assert "current-main" not in js_text
     assert "isServingTrendWorkload(entry) && isMainlineTrendEntry(entry)" in js_text
     assert "function renderPerformanceTrendChart(entries)" in js_text
     assert "new Chart(canvas" in js_text
@@ -514,6 +521,61 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert ".trend-axis-row {" in css_text
     assert ".trend-axis-toggle {" in css_text
     assert ".trend-axis-button.active {" in css_text
+
+
+def test_multichip_trend_filter_covers_mainline_online_workloads() -> None:
+    root = Path(__file__).resolve().parents[1]
+    data = json.loads((root / "data" / "leaderboard_multi.json").read_text())
+
+    def workload(entry: dict) -> str:
+        return entry.get("workload", {}).get("name", "")
+
+    def is_baseline(entry: dict) -> bool:
+        return bool(entry.get("isBaseline")) or entry.get("engine") != "vllm-hust"
+
+    def ref_tokens(entry: dict) -> set[str]:
+        ref = str(entry.get("metadata", {}).get("github_ref") or "").lower()
+        return {token for token in re.split(r"[^a-z0-9]+", ref) if token}
+
+    def has_pr_metadata(entry: dict) -> bool:
+        metadata = entry.get("metadata", {})
+        return bool(metadata.get("github_pr_number") or metadata.get("github_pr_url"))
+
+    def is_mainline(entry: dict) -> bool:
+        return is_baseline(entry) or (
+            not has_pr_metadata(entry) and "main" in ref_tokens(entry)
+        )
+
+    def is_serving_workload(entry: dict) -> bool:
+        base = re.sub(r"-\d+chip$", "", workload(entry))
+        return base.endswith(("-online", "-throughput", "-latency"))
+
+    rows = [
+        entry for entry in data if is_serving_workload(entry) and is_mainline(entry)
+    ]
+    online_chip_workloads = sorted(
+        {
+            workload(entry)
+            for entry in data
+            if re.search(r"-online-\d+chip$", workload(entry))
+        }
+    )
+    assert online_chip_workloads
+
+    refs_by_workload: dict[str, set[str]] = {
+        name: set() for name in online_chip_workloads
+    }
+    for entry in rows:
+        name = workload(entry)
+        if name in refs_by_workload:
+            refs_by_workload[name].add(entry.get("metadata", {}).get("github_ref", ""))
+
+    for name, refs in refs_by_workload.items():
+        assert "v0.18.0" in refs, f"{name} should include the baseline point"
+        assert any(
+            "main" in {token for token in re.split(r"[^a-z0-9]+", ref.lower()) if token}
+            for ref in refs
+        ), f"{name} should include at least one non-PR mainline point"
 
 
 def test_detail_sections_use_detail_only_version_formatting_and_memory_fallback() -> (


### PR DESCRIPTION
## Summary
- replace hard-coded mainline ref checks with tokenized `github_ref` handling: non-PR rows whose ref contains a `main` token are treated as mainline
- normalize workload names by stripping chip-count suffixes before serving-workload classification
- add a data-driven multi-chip regression test so `*-online-2chip/4chip` mainline rows are not silently dropped from All trends
- bump leaderboard asset token so the deployed page loads the generalized JavaScript

## Validation
- node --check assets/leaderboard.js
- python3 -m pytest tests/test_site_structure.py::test_leaderboard_renders_interactive_trend_chart tests/test_site_structure.py::test_multichip_trend_filter_covers_mainline_online_workloads -q
- git diff --check

Note: running the full local `tests/test_site_structure.py` in this server worktree currently also checks the sibling benchmark snapshot mirror and reports unrelated data drift between `vllm-hust-website/data` and `../vllm-hust-benchmark/leaderboard-data/snapshots`.