### PR TITLE
fix: focus trend axis around main throughput cluster

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -237,6 +237,8 @@
             trendAxisAuto: 'Auto',
             trendAxisLog: 'Log',
             trendAxisLinear: 'Linear',
+            trendTooltipActualValue: 'Actual',
+            trendTooltipClipped: 'clipped to focused axis',
             trendEmpty: 'No trend data under current filters.',
             trendTooltipVersion: 'Version',
             trendTooltipDate: 'Submitted',
@@ -443,6 +445,8 @@
             trendAxisAuto: '自动',
             trendAxisLog: '对数',
             trendAxisLinear: '线性',
+            trendTooltipActualValue: '实际值',
+            trendTooltipClipped: '已按聚焦坐标截断显示',
             trendEmpty: '当前筛选条件下没有可绘制的趋势数据。',
             trendTooltipVersion: '版本',
             trendTooltipDate: '提交时间',
@@ -2526,22 +2530,56 @@
             .map(Number);
     }
 
-    const LOG_TREND_AXIS_RATIO_THRESHOLD = 20;
+    const FOCUSED_TREND_AXIS_RATIO_THRESHOLD = 8;
+    const FOCUSED_TREND_AXIS_MEDIAN_MULTIPLIER = 3;
 
-    function shouldUseLogTrendAxis(metricConfig, datasets) {
-        const values = getTrendAxisValues(datasets).filter((value) => value > 0);
-        if (values.length < 2) {
-            return false;
+    function getSortedPositiveTrendValues(datasets) {
+        return getTrendAxisValues(datasets)
+            .filter((value) => value > 0)
+            .sort((left, right) => left - right);
+    }
+
+    function getTrendMedian(values) {
+        if (!values.length) {
+            return 0;
         }
-        if (state.trendAxisScale === 'log') {
-            return true;
+        const middle = Math.floor(values.length / 2);
+        return values.length % 2 === 0
+            ? (values[middle - 1] + values[middle]) / 2
+            : values[middle];
+    }
+
+    function getFocusedTrendAxisBounds(metricConfig, datasets) {
+        if (state.trendAxisScale !== 'auto' || metricConfig.key !== 'throughput_tps') {
+            return null;
         }
-        if (state.trendAxisScale === 'linear' || metricConfig.key !== 'throughput_tps') {
-            return false;
+        const values = getSortedPositiveTrendValues(datasets);
+        if (values.length < 4) {
+            return null;
         }
-        const minValue = Math.min(...values);
-        const maxValue = Math.max(...values);
-        return maxValue / minValue >= LOG_TREND_AXIS_RATIO_THRESHOLD;
+        const median = getTrendMedian(values);
+        const max = values[values.length - 1];
+        if (!median || max / median < FOCUSED_TREND_AXIS_RATIO_THRESHOLD) {
+            return null;
+        }
+
+        const focusedMax = median * FOCUSED_TREND_AXIS_MEDIAN_MULTIPLIER;
+        const inFocusValues = values.filter((value) => value <= focusedMax);
+        if (inFocusValues.length < 2 || inFocusValues.length === values.length) {
+            return null;
+        }
+
+        const min = Math.min(...inFocusValues);
+        const visibleMax = Math.max(...inFocusValues, focusedMax);
+        return {
+            min: Math.max(min * 0.85, 0),
+            max: visibleMax * 1.12,
+            clipValue: visibleMax,
+        };
+    }
+
+    function shouldUseLogTrendAxis() {
+        return state.trendAxisScale === 'log';
     }
 
     function getLogTrendAxisBounds(datasets) {
@@ -2648,14 +2686,25 @@
             };
         });
 
-        const useLogYAxis = shouldUseLogTrendAxis(metricConfig, datasets);
-        const yAxisBounds = useLogYAxis ? getLogTrendAxisBounds(datasets) : {};
-        if (useLogYAxis) {
+        const focusedYAxisBounds = getFocusedTrendAxisBounds(metricConfig, datasets);
+        const useLogYAxis = shouldUseLogTrendAxis();
+        const yAxisBounds = useLogYAxis
+            ? getLogTrendAxisBounds(datasets)
+            : (focusedYAxisBounds || {});
+        if (useLogYAxis || focusedYAxisBounds) {
             datasets = datasets.map((dataset) => ({
                 ...dataset,
+                rawData: dataset.data,
                 data: dataset.data.map((value) => {
                     const number = Number(value);
-                    return Number.isFinite(number) && number > 0 ? number : null;
+                    if (!Number.isFinite(number) || (useLogYAxis && number <= 0)) {
+                        return null;
+                    }
+                    return focusedYAxisBounds ? Math.min(number, focusedYAxisBounds.clipValue) : number;
+                }),
+                clippedData: dataset.data.map((value) => {
+                    const number = Number(value);
+                    return Boolean(focusedYAxisBounds && Number.isFinite(number) && number > focusedYAxisBounds.clipValue);
                 }),
             }));
         }
@@ -2697,16 +2746,27 @@
                                 return item ? String(item.label || '') : '';
                             },
                             label(context) {
-                                const value = Number(context.parsed.y);
-                                const formatted = Number.isFinite(value) ? formatNumber(value) : '-';
-                                return `${context.dataset.label}: ${formatted} ${metricConfig.unit}`;
+                                const rawValue = Number(context.dataset.rawData?.[context.dataIndex] ?? context.parsed.y);
+                                const formatted = Number.isFinite(rawValue) ? formatNumber(rawValue) : '-';
+                                const suffix = context.dataset.clippedData?.[context.dataIndex]
+                                    ? ` (${t('trendTooltipClipped')})`
+                                    : '';
+                                return `${context.dataset.label}: ${formatted} ${metricConfig.unit}${suffix}`;
                             },
                             afterLabel(context) {
                                 const details = context.dataset.pointDetails?.[context.dataIndex];
                                 if (!details) {
                                     return [];
                                 }
+                                const extra = [];
+                                if (context.dataset.clippedData?.[context.dataIndex]) {
+                                    const rawValue = Number(context.dataset.rawData?.[context.dataIndex]);
+                                    if (Number.isFinite(rawValue)) {
+                                        extra.push(`${t('trendTooltipActualValue')}: ${formatNumber(rawValue)} ${metricConfig.unit}`);
+                                    }
+                                }
                                 return [
+                                    ...extra,
                                     `${t('trendTooltipVersion')}: ${details.version}`,
                                     `${t('trendTooltipDate')}: ${details.date}`,
                                     `${t('trendTooltipWorkload')}: ${details.workload}`,

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="./assets/brand/vllm-hust-icon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=public-copy-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-generic-trends1" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-focused-axis1" />
 </head>
 
 <body data-page="leaderboard">
@@ -200,7 +200,7 @@
   <script src="./assets/site.js?v=public-copy-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v7-20260702"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-generic-trends1"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-focused-axis1"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -464,7 +464,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert 'data-trend-axis="log"' in html_text
     assert 'data-trend-axis="linear"' in html_text
     assert "leaderboard-cache-v7-20260702" in html_text
-    assert "leaderboard-public-20260706-generic-trends1" in html_text
+    assert "leaderboard-public-20260706-focused-axis1" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert (
         "const sortValue = baseline ? Number.NEGATIVE_INFINITY : (timestamp || 0);"
@@ -509,22 +509,26 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "spanGaps: true" in js_text
     assert "Keep one series continuous across x-axis slots" in js_text
     assert "function getTrendAxisValues(datasets)" in js_text
-    assert "function shouldUseLogTrendAxis(metricConfig, datasets)" in js_text
+    assert "function shouldUseLogTrendAxis()" in js_text
     assert "trendAxisScale: 'auto'" in js_text
-    assert "const LOG_TREND_AXIS_RATIO_THRESHOLD = 20;" in js_text
-    assert "state.trendAxisScale === 'log'" in js_text
-    assert "state.trendAxisScale === 'linear'" in js_text
-    assert "const minValue = Math.min(...values);" in js_text
-    assert "const maxValue = Math.max(...values);" in js_text
-    assert "return maxValue / minValue >= LOG_TREND_AXIS_RATIO_THRESHOLD;" in js_text
-    assert "document.querySelectorAll('[data-trend-axis]')" in js_text
-    assert "data: dataset.data.map((value) => {" in js_text
-    assert "Number.isFinite(number) && number > 0 ? number : null" in js_text
-    assert "function getLogTrendAxisBounds(datasets)" in js_text
+    assert "const FOCUSED_TREND_AXIS_RATIO_THRESHOLD = 8;" in js_text
+    assert "function getSortedPositiveTrendValues(datasets)" in js_text
+    assert "function getTrendMedian(values)" in js_text
+    assert "function getFocusedTrendAxisBounds(metricConfig, datasets)" in js_text
+    assert "FOCUSED_TREND_AXIS_MEDIAN_MULTIPLIER" in js_text
+    assert "max / median < FOCUSED_TREND_AXIS_RATIO_THRESHOLD" in js_text
     assert (
-        "const yAxisBounds = useLogYAxis ? getLogTrendAxisBounds(datasets) : {};"
+        "const focusedYAxisBounds = getFocusedTrendAxisBounds(metricConfig, datasets);"
         in js_text
     )
+    assert "rawData: dataset.data" in js_text
+    assert "clippedData: dataset.data.map((value) => {" in js_text
+    assert "state.trendAxisScale === 'log'" in js_text
+    assert "document.querySelectorAll('[data-trend-axis]')" in js_text
+    assert "data: dataset.data.map((value) => {" in js_text
+    assert "Math.min(number, focusedYAxisBounds.clipValue)" in js_text
+    assert "function getLogTrendAxisBounds(datasets)" in js_text
+    assert "focusedYAxisBounds || {}" in js_text
     assert "type: useLogYAxis ? 'logarithmic' : 'linear'" in js_text
     assert "min: yAxisBounds.min" in js_text
     assert "function getPerformanceTrendEntries(entries, selectedWorkload)" in js_text
@@ -539,6 +543,33 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert ".trend-axis-row {" in css_text
     assert ".trend-axis-toggle {" in css_text
     assert ".trend-axis-button.active {" in css_text
+
+
+def test_single_chip_all_workload_auto_axis_focuses_outliers() -> None:
+    root = Path(__file__).resolve().parents[1]
+    data = json.loads((root / "data" / "leaderboard_single.json").read_text())
+
+    values = [
+        float(entry.get("metrics", {}).get("throughput_tps") or 0)
+        for entry in data
+        if entry.get("workload", {}).get("name")
+        and float(entry.get("metrics", {}).get("throughput_tps") or 0) > 0
+    ]
+    values.sort()
+    assert len(values) >= 4
+
+    median_index = len(values) // 2
+    median = (
+        (values[median_index - 1] + values[median_index]) / 2
+        if len(values) % 2 == 0
+        else values[median_index]
+    )
+    focused_max = median * 3
+    in_focus_values = [value for value in values if value <= focused_max]
+
+    assert values[-1] / median >= 8
+    assert len(in_focus_values) < len(values)
+    assert max(in_focus_values) < values[-1]
 
 
 def test_multichip_trend_filter_covers_mainline_online_workloads() -> None:


### PR DESCRIPTION
## Summary
- change Auto Y-axis behavior for throughput trends to focus on the main performance cluster when large outliers are present
- clipped outlier points keep their real values in tooltip text while the chart uses a focused linear axis
- keep explicit Log and Linear axis controls available
- bump the leaderboard asset token for deployment cache busting

## Validation
- node --check assets/leaderboard.js
- git diff --check
- python3 -m pytest tests/test_site_structure.py::test_leaderboard_renders_interactive_trend_chart tests/test_site_structure.py::test_single_chip_all_workload_auto_axis_focuses_outliers tests/test_site_structure.py::test_multichip_trend_filter_covers_mainline_online_workloads -q
- current single-chip data: median 168.1 tok/s, max 4666.8 tok/s, focused clip around 504.2 tok/s, 16 outlier values clipped for display only