### PR TITLE
Fix focused trend axis rendering

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -2569,10 +2569,9 @@
             return null;
         }
 
-        const min = Math.min(...inFocusValues);
         const visibleMax = Math.max(...inFocusValues, focusedMax);
         return {
-            min: Math.max(min * 0.85, 0),
+            min: 0,
             max: visibleMax * 1.12,
             clipValue: visibleMax,
         };
@@ -2694,6 +2693,7 @@
         if (useLogYAxis || focusedYAxisBounds) {
             datasets = datasets.map((dataset) => ({
                 ...dataset,
+                tension: focusedYAxisBounds ? 0 : dataset.tension,
                 rawData: dataset.data,
                 data: dataset.data.map((value) => {
                     const number = Number(value);

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="./assets/brand/vllm-hust-icon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=public-copy-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-focused-axis1" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-focused-axis2" />
 </head>
 
 <body data-page="leaderboard">
@@ -200,7 +200,7 @@
   <script src="./assets/site.js?v=public-copy-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v7-20260702"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-focused-axis1"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-focused-axis2"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -461,7 +461,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert 'data-trend-axis="log"' in html_text
     assert 'data-trend-axis="linear"' in html_text
     assert "leaderboard-cache-v7-20260702" in html_text
-    assert "leaderboard-public-20260706-focused-axis1" in html_text
+    assert "leaderboard-public-20260706-focused-axis2" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert (
         "const sortValue = baseline ? Number.NEGATIVE_INFINITY : (timestamp || 0);"
@@ -526,6 +526,8 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "Math.min(number, focusedYAxisBounds.clipValue)" in js_text
     assert "function getLogTrendAxisBounds(datasets)" in js_text
     assert "focusedYAxisBounds || {}" in js_text
+    assert "min: 0," in js_text
+    assert "tension: focusedYAxisBounds ? 0 : dataset.tension" in js_text
     assert "type: useLogYAxis ? 'logarithmic' : 'linear'" in js_text
     assert "min: yAxisBounds.min" in js_text
     assert "function getPerformanceTrendEntries(entries, selectedWorkload)" in js_text


### PR DESCRIPTION
## Summary
- keep the focused auto Y-axis lower bound at zero so low-throughput series remain visible
- disable line smoothing only in focused-axis mode to avoid spline overshoot after clipping high outliers
- bump the leaderboard asset cache token

## Tests
- node --check assets/leaderboard.js
- python3 -m pytest tests/test_site_structure.py::test_leaderboard_renders_interactive_trend_chart tests/test_site_structure.py::test_single_chip_all_workload_auto_axis_focuses_outliers -q