### PR TITLE
Use broken axis for all-workload trend outliers

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -237,8 +237,9 @@
             trendAxisAuto: 'Auto',
             trendAxisLog: 'Log',
             trendAxisLinear: 'Linear',
+            trendAxisBreak: 'axis break',
             trendTooltipActualValue: 'Actual',
-            trendTooltipClipped: 'clipped to focused axis',
+            trendTooltipBrokenAxis: 'shown on broken axis',
             trendEmpty: 'No trend data under current filters.',
             trendTooltipVersion: 'Version',
             trendTooltipDate: 'Submitted',
@@ -445,8 +446,9 @@
             trendAxisAuto: '自动',
             trendAxisLog: '对数',
             trendAxisLinear: '线性',
+            trendAxisBreak: '断轴',
             trendTooltipActualValue: '实际值',
-            trendTooltipClipped: '已按聚焦坐标截断显示',
+            trendTooltipBrokenAxis: '断轴显示',
             trendEmpty: '当前筛选条件下没有可绘制的趋势数据。',
             trendTooltipVersion: '版本',
             trendTooltipDate: '提交时间',
@@ -2530,8 +2532,9 @@
             .map(Number);
     }
 
-    const FOCUSED_TREND_AXIS_RATIO_THRESHOLD = 8;
-    const FOCUSED_TREND_AXIS_MEDIAN_MULTIPLIER = 3;
+    const BROKEN_TREND_AXIS_RATIO_THRESHOLD = 8;
+    const BROKEN_TREND_AXIS_MEDIAN_MULTIPLIER = 3;
+    const BROKEN_TREND_AXIS_HIGH_SEGMENT_MULTIPLIER = 1.25;
 
     function getSortedPositiveTrendValues(datasets) {
         return getTrendAxisValues(datasets)
@@ -2549,7 +2552,7 @@
             : values[middle];
     }
 
-    function getFocusedTrendAxisBounds(metricConfig, datasets) {
+    function getBrokenTrendAxisConfig(metricConfig, datasets) {
         if (state.trendAxisScale !== 'auto' || metricConfig.key !== 'throughput_tps') {
             return null;
         }
@@ -2559,23 +2562,98 @@
         }
         const median = getTrendMedian(values);
         const max = values[values.length - 1];
-        if (!median || max / median < FOCUSED_TREND_AXIS_RATIO_THRESHOLD) {
+        if (!median || max / median < BROKEN_TREND_AXIS_RATIO_THRESHOLD) {
             return null;
         }
 
-        const focusedMax = median * FOCUSED_TREND_AXIS_MEDIAN_MULTIPLIER;
-        const inFocusValues = values.filter((value) => value <= focusedMax);
-        if (inFocusValues.length < 2 || inFocusValues.length === values.length) {
+        const lowMax = median * BROKEN_TREND_AXIS_MEDIAN_MULTIPLIER;
+        const highValues = values.filter((value) => value > lowMax);
+        const lowValues = values.filter((value) => value <= lowMax);
+        if (lowValues.length < 2 || highValues.length < 1) {
             return null;
         }
 
-        const visibleMax = Math.max(...inFocusValues, focusedMax);
+        const highMin = Math.min(...highValues);
+        const highMax = Math.max(...highValues);
+        if (highMax <= highMin) {
+            return null;
+        }
+        const highDisplayMin = lowMax * 1.18;
+        const highDisplayMax = lowMax * BROKEN_TREND_AXIS_HIGH_SEGMENT_MULTIPLIER * 2;
         return {
+            lowMax,
+            highMin,
+            highMax,
+            highDisplayMin,
+            highDisplayMax,
             min: 0,
-            max: visibleMax * 1.12,
-            clipValue: visibleMax,
+            max: highDisplayMax * 1.08,
         };
     }
+
+    function mapBrokenTrendAxisValue(value, axisConfig) {
+        const number = Number(value);
+        if (!Number.isFinite(number)) {
+            return null;
+        }
+        if (!axisConfig || number <= axisConfig.lowMax) {
+            return number;
+        }
+        const sourceRange = axisConfig.highMax - axisConfig.highMin;
+        const displayRange = axisConfig.highDisplayMax - axisConfig.highDisplayMin;
+        if (sourceRange <= 0 || displayRange <= 0) {
+            return number;
+        }
+        const ratio = Math.max(0, Math.min(1, (number - axisConfig.highMin) / sourceRange));
+        return axisConfig.highDisplayMin + ratio * displayRange;
+    }
+
+    function unmapBrokenTrendAxisValue(value, axisConfig) {
+        const number = Number(value);
+        if (!Number.isFinite(number) || !axisConfig || number <= axisConfig.lowMax) {
+            return number;
+        }
+        if (number < axisConfig.highDisplayMin) {
+            return null;
+        }
+        const displayRange = axisConfig.highDisplayMax - axisConfig.highDisplayMin;
+        const sourceRange = axisConfig.highMax - axisConfig.highMin;
+        if (displayRange <= 0 || sourceRange <= 0) {
+            return number;
+        }
+        const ratio = Math.max(0, Math.min(1, (number - axisConfig.highDisplayMin) / displayRange));
+        return axisConfig.highMin + ratio * sourceRange;
+    }
+
+    const brokenTrendAxisPlugin = {
+        id: 'brokenTrendAxis',
+        afterDraw(chart, _args, options) {
+            const axisConfig = options?.axisConfig;
+            const yScale = chart.scales?.y;
+            const area = chart.chartArea;
+            if (!axisConfig || !yScale || !area) {
+                return;
+            }
+            const gapMiddle = (axisConfig.lowMax + axisConfig.highDisplayMin) / 2;
+            const y = yScale.getPixelForValue(gapMiddle);
+            const ctx = chart.ctx;
+            ctx.save();
+            ctx.strokeStyle = 'rgba(226, 246, 255, 0.82)';
+            ctx.lineWidth = 2;
+            const left = area.left - 10;
+            const right = area.left + 18;
+            ctx.beginPath();
+            ctx.moveTo(left, y + 8);
+            ctx.lineTo(left + 10, y - 8);
+            ctx.moveTo(left + 12, y + 8);
+            ctx.lineTo(right, y - 8);
+            ctx.stroke();
+            ctx.fillStyle = 'rgba(226, 246, 255, 0.74)';
+            ctx.font = '600 11px Inter, sans-serif';
+            ctx.fillText(t('trendAxisBreak'), area.left + 8, y - 10);
+            ctx.restore();
+        },
+    };
 
     function shouldUseLogTrendAxis() {
         return state.trendAxisScale === 'log';
@@ -2685,26 +2763,26 @@
             };
         });
 
-        const focusedYAxisBounds = getFocusedTrendAxisBounds(metricConfig, datasets);
+        const brokenYAxisConfig = getBrokenTrendAxisConfig(metricConfig, datasets);
         const useLogYAxis = shouldUseLogTrendAxis();
         const yAxisBounds = useLogYAxis
             ? getLogTrendAxisBounds(datasets)
-            : (focusedYAxisBounds || {});
-        if (useLogYAxis || focusedYAxisBounds) {
+            : (brokenYAxisConfig || {});
+        if (useLogYAxis || brokenYAxisConfig) {
             datasets = datasets.map((dataset) => ({
                 ...dataset,
-                tension: focusedYAxisBounds ? 0 : dataset.tension,
+                tension: brokenYAxisConfig ? 0 : dataset.tension,
                 rawData: dataset.data,
                 data: dataset.data.map((value) => {
                     const number = Number(value);
                     if (!Number.isFinite(number) || (useLogYAxis && number <= 0)) {
                         return null;
                     }
-                    return focusedYAxisBounds ? Math.min(number, focusedYAxisBounds.clipValue) : number;
+                    return brokenYAxisConfig ? mapBrokenTrendAxisValue(number, brokenYAxisConfig) : number;
                 }),
-                clippedData: dataset.data.map((value) => {
+                brokenAxisData: dataset.data.map((value) => {
                     const number = Number(value);
-                    return Boolean(focusedYAxisBounds && Number.isFinite(number) && number > focusedYAxisBounds.clipValue);
+                    return Boolean(brokenYAxisConfig && Number.isFinite(number) && number > brokenYAxisConfig.lowMax);
                 }),
             }));
         }
@@ -2715,6 +2793,7 @@
 
         state.trendChart = new Chart(canvas, {
             type: 'line',
+            plugins: brokenYAxisConfig ? [brokenTrendAxisPlugin] : [],
             data: { labels, datasets },
             options: {
                 responsive: true,
@@ -2724,6 +2803,9 @@
                     intersect: false,
                 },
                 plugins: {
+                    brokenTrendAxis: {
+                        axisConfig: brokenYAxisConfig,
+                    },
                     legend: {
                         position: 'bottom',
                         labels: {
@@ -2748,8 +2830,8 @@
                             label(context) {
                                 const rawValue = Number(context.dataset.rawData?.[context.dataIndex] ?? context.parsed.y);
                                 const formatted = Number.isFinite(rawValue) ? formatNumber(rawValue) : '-';
-                                const suffix = context.dataset.clippedData?.[context.dataIndex]
-                                    ? ` (${t('trendTooltipClipped')})`
+                                const suffix = context.dataset.brokenAxisData?.[context.dataIndex]
+                                    ? ` (${t('trendTooltipBrokenAxis')})`
                                     : '';
                                 return `${context.dataset.label}: ${formatted} ${metricConfig.unit}${suffix}`;
                             },
@@ -2759,7 +2841,7 @@
                                     return [];
                                 }
                                 const extra = [];
-                                if (context.dataset.clippedData?.[context.dataIndex]) {
+                                if (context.dataset.brokenAxisData?.[context.dataIndex]) {
                                     const rawValue = Number(context.dataset.rawData?.[context.dataIndex]);
                                     if (Number.isFinite(rawValue)) {
                                         extra.push(`${t('trendTooltipActualValue')}: ${formatNumber(rawValue)} ${metricConfig.unit}`);
@@ -2800,7 +2882,8 @@
                         ticks: {
                             color: '#dff3ff',
                             callback(value) {
-                                return formatNumber(Number(value));
+                                const axisValue = brokenYAxisConfig ? unmapBrokenTrendAxisValue(value, brokenYAxisConfig) : Number(value);
+                                return Number.isFinite(axisValue) ? formatNumber(axisValue) : '⋯';
                             },
                         },
                         title: {

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="./assets/brand/vllm-hust-icon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=public-copy-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-focused-axis3" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-broken-axis1" />
 </head>
 
 <body data-page="leaderboard">
@@ -200,7 +200,7 @@
   <script src="./assets/site.js?v=public-copy-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v7-20260702"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-focused-axis3"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-broken-axis1"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -461,7 +461,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert 'data-trend-axis="log"' in html_text
     assert 'data-trend-axis="linear"' in html_text
     assert "leaderboard-cache-v7-20260702" in html_text
-    assert "leaderboard-public-20260706-focused-axis3" in html_text
+    assert "leaderboard-public-20260706-broken-axis1" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert (
         "const sortValue = baseline ? Number.NEGATIVE_INFINITY : (timestamp || 0);"
@@ -508,26 +508,32 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "function getTrendAxisValues(datasets)" in js_text
     assert "function shouldUseLogTrendAxis()" in js_text
     assert "trendAxisScale: 'auto'" in js_text
-    assert "const FOCUSED_TREND_AXIS_RATIO_THRESHOLD = 8;" in js_text
+    assert "const BROKEN_TREND_AXIS_RATIO_THRESHOLD = 8;" in js_text
     assert "function getSortedPositiveTrendValues(datasets)" in js_text
     assert "function getTrendMedian(values)" in js_text
-    assert "function getFocusedTrendAxisBounds(metricConfig, datasets)" in js_text
-    assert "FOCUSED_TREND_AXIS_MEDIAN_MULTIPLIER" in js_text
-    assert "max / median < FOCUSED_TREND_AXIS_RATIO_THRESHOLD" in js_text
+    assert "function getBrokenTrendAxisConfig(metricConfig, datasets)" in js_text
+    assert "BROKEN_TREND_AXIS_MEDIAN_MULTIPLIER" in js_text
+    assert "max / median < BROKEN_TREND_AXIS_RATIO_THRESHOLD" in js_text
     assert (
-        "const focusedYAxisBounds = getFocusedTrendAxisBounds(metricConfig, datasets);"
+        "const brokenYAxisConfig = getBrokenTrendAxisConfig(metricConfig, datasets);"
         in js_text
     )
     assert "rawData: dataset.data" in js_text
-    assert "clippedData: dataset.data.map((value) => {" in js_text
+    assert "brokenAxisData: dataset.data.map((value) => {" in js_text
     assert "state.trendAxisScale === 'log'" in js_text
     assert "document.querySelectorAll('[data-trend-axis]')" in js_text
     assert "data: dataset.data.map((value) => {" in js_text
-    assert "Math.min(number, focusedYAxisBounds.clipValue)" in js_text
+    assert "mapBrokenTrendAxisValue(number, brokenYAxisConfig)" in js_text
     assert "function getLogTrendAxisBounds(datasets)" in js_text
-    assert "focusedYAxisBounds || {}" in js_text
+    assert "brokenYAxisConfig || {}" in js_text
+    assert "function mapBrokenTrendAxisValue(value, axisConfig)" in js_text
+    assert "function unmapBrokenTrendAxisValue(value, axisConfig)" in js_text
+    assert "trendAxisBreak" in js_text
+    assert "ctx.fillText(t('trendAxisBreak')" in js_text
+    assert "const brokenTrendAxisPlugin = {" in js_text
+    assert "plugins: brokenYAxisConfig ? [brokenTrendAxisPlugin] : []" in js_text
     assert "min: 0," in js_text
-    assert "tension: focusedYAxisBounds ? 0 : dataset.tension" in js_text
+    assert "tension: brokenYAxisConfig ? 0 : dataset.tension" in js_text
     assert "type: useLogYAxis ? 'logarithmic' : 'linear'" in js_text
     assert "min: yAxisBounds.min" in js_text
     assert "function getPerformanceTrendEntries(entries, selectedWorkload)" in js_text
@@ -544,7 +550,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert ".trend-axis-button.active {" in css_text
 
 
-def test_single_chip_all_workload_auto_axis_focuses_outliers() -> None:
+def test_single_chip_all_workload_auto_axis_uses_broken_axis_for_outliers() -> None:
     root = Path(__file__).resolve().parents[1]
     data = json.loads((root / "data" / "leaderboard_single.json").read_text())
 


### PR DESCRIPTION
## Summary
- replace focused-axis clipping with a two-segment broken Y-axis for automatic throughput trends
- preserve high-throughput outlier points by mapping them into an upper segment instead of hiding or clipping them
- keep raw values in tooltips and show a translated axis-break marker
- bump the leaderboard asset cache token

## Tests
- node --check assets/leaderboard.js
- python3 -m pytest tests/test_site_structure.py::test_leaderboard_renders_interactive_trend_chart tests/test_site_structure.py::test_single_chip_all_workload_auto_axis_uses_broken_axis_for_outliers -q

Note: full `python3 -m pytest tests/test_site_structure.py -q` has one local-only failure because `/home/shuhao/vllm-hust-benchmark/leaderboard-data/snapshots/leaderboard_single.json` is not synced with website data; unrelated to this frontend chart change.