### PR TITLE
Preserve missing trend values in broken axis mode

### DIFF
--- a/assets/leaderboard.js
+++ b/assets/leaderboard.js
@@ -2525,10 +2525,14 @@
     }
 
 
+    function isMissingTrendValue(value) {
+        return value === null || value === undefined || value === '';
+    }
+
     function getTrendAxisValues(datasets) {
         return datasets
             .flatMap((dataset) => dataset.data || [])
-            .filter((value) => Number.isFinite(Number(value)))
+            .filter((value) => !isMissingTrendValue(value) && Number.isFinite(Number(value)))
             .map(Number);
     }
 
@@ -2774,6 +2778,9 @@
                 tension: brokenYAxisConfig ? 0 : dataset.tension,
                 rawData: dataset.data,
                 data: dataset.data.map((value) => {
+                    if (isMissingTrendValue(value)) {
+                        return null;
+                    }
                     const number = Number(value);
                     if (!Number.isFinite(number) || (useLogYAxis && number <= 0)) {
                         return null;
@@ -2781,6 +2788,9 @@
                     return brokenYAxisConfig ? mapBrokenTrendAxisValue(number, brokenYAxisConfig) : number;
                 }),
                 brokenAxisData: dataset.data.map((value) => {
+                    if (isMissingTrendValue(value)) {
+                        return false;
+                    }
                     const number = Number(value);
                     return Boolean(brokenYAxisConfig && Number.isFinite(number) && number > brokenYAxisConfig.lowMax);
                 }),
@@ -2828,7 +2838,8 @@
                                 return item ? String(item.label || '') : '';
                             },
                             label(context) {
-                                const rawValue = Number(context.dataset.rawData?.[context.dataIndex] ?? context.parsed.y);
+                                const sourceValue = context.dataset.rawData?.[context.dataIndex];
+                                const rawValue = isMissingTrendValue(sourceValue) ? NaN : Number(sourceValue);
                                 const formatted = Number.isFinite(rawValue) ? formatNumber(rawValue) : '-';
                                 const suffix = context.dataset.brokenAxisData?.[context.dataIndex]
                                     ? ` (${t('trendTooltipBrokenAxis')})`
@@ -2842,7 +2853,8 @@
                                 }
                                 const extra = [];
                                 if (context.dataset.brokenAxisData?.[context.dataIndex]) {
-                                    const rawValue = Number(context.dataset.rawData?.[context.dataIndex]);
+                                    const sourceValue = context.dataset.rawData?.[context.dataIndex];
+                                    const rawValue = isMissingTrendValue(sourceValue) ? NaN : Number(sourceValue);
                                     if (Number.isFinite(rawValue)) {
                                         extra.push(`${t('trendTooltipActualValue')}: ${formatNumber(rawValue)} ${metricConfig.unit}`);
                                     }

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -16,7 +16,7 @@
   <link rel="apple-touch-icon" href="./assets/brand/vllm-hust-icon.png" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Fira+Code&family=Sora:wght@600;700;800;900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./assets/site.css?v=public-copy-20260701" />
-  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-broken-axis1" />
+  <link rel="stylesheet" href="./assets/leaderboard.css?v=leaderboard-public-20260706-broken-axis2" />
 </head>
 
 <body data-page="leaderboard">
@@ -200,7 +200,7 @@
   <script src="./assets/site.js?v=public-copy-20260701"></script>
   <script src="./assets/hf-data-loader.js?v=leaderboard-cache-v7-20260702"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
-  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-broken-axis1"></script>
+  <script src="./assets/leaderboard.js?v=leaderboard-public-20260706-broken-axis2"></script>
 </body>
 
 </html>

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -461,7 +461,7 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert 'data-trend-axis="log"' in html_text
     assert 'data-trend-axis="linear"' in html_text
     assert "leaderboard-cache-v7-20260702" in html_text
-    assert "leaderboard-public-20260706-broken-axis1" in html_text
+    assert "leaderboard-public-20260706-broken-axis2" in html_text
     assert "function buildTrendChartModel(entries, metricConfig)" in js_text
     assert (
         "const sortValue = baseline ? Number.NEGATIVE_INFINITY : (timestamp || 0);"
@@ -509,6 +509,8 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "function shouldUseLogTrendAxis()" in js_text
     assert "trendAxisScale: 'auto'" in js_text
     assert "const BROKEN_TREND_AXIS_RATIO_THRESHOLD = 8;" in js_text
+    assert "function isMissingTrendValue(value)" in js_text
+    assert "!isMissingTrendValue(value) && Number.isFinite(Number(value))" in js_text
     assert "function getSortedPositiveTrendValues(datasets)" in js_text
     assert "function getTrendMedian(values)" in js_text
     assert "function getBrokenTrendAxisConfig(metricConfig, datasets)" in js_text
@@ -524,6 +526,9 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "document.querySelectorAll('[data-trend-axis]')" in js_text
     assert "data: dataset.data.map((value) => {" in js_text
     assert "mapBrokenTrendAxisValue(number, brokenYAxisConfig)" in js_text
+    assert "if (isMissingTrendValue(value))" in js_text
+    assert "const sourceValue = context.dataset.rawData?.[context.dataIndex]" in js_text
+    assert "const rawValue = isMissingTrendValue(sourceValue) ? NaN : Number(sourceValue)" in js_text
     assert "function getLogTrendAxisBounds(datasets)" in js_text
     assert "brokenYAxisConfig || {}" in js_text
     assert "function mapBrokenTrendAxisValue(value, axisConfig)" in js_text

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -528,7 +528,10 @@ def test_leaderboard_renders_interactive_trend_chart() -> None:
     assert "mapBrokenTrendAxisValue(number, brokenYAxisConfig)" in js_text
     assert "if (isMissingTrendValue(value))" in js_text
     assert "const sourceValue = context.dataset.rawData?.[context.dataIndex]" in js_text
-    assert "const rawValue = isMissingTrendValue(sourceValue) ? NaN : Number(sourceValue)" in js_text
+    assert (
+        "const rawValue = isMissingTrendValue(sourceValue) ? NaN : Number(sourceValue)"
+        in js_text
+    )
     assert "function getLogTrendAxisBounds(datasets)" in js_text
     assert "brokenYAxisConfig || {}" in js_text
     assert "function mapBrokenTrendAxisValue(value, axisConfig)" in js_text


### PR DESCRIPTION
## Summary
- keep null/undefined/empty trend points as missing values when applying log or broken-axis transforms
- prevent missing points from becoming 0.0 tok/s in tooltips and line data
- bump the leaderboard asset cache token

## Tests
- node --check assets/leaderboard.js
- python3 -m pytest tests/test_site_structure.py::test_leaderboard_renders_interactive_trend_chart tests/test_site_structure.py::test_single_chip_all_workload_auto_axis_uses_broken_axis_for_outliers -q