### PR TITLE
Prefer Chinese contributor names on contributors page

### DIFF
--- a/assets/contributors-page.js
+++ b/assets/contributors-page.js
@@ -47,14 +47,18 @@
         const tbody = document.getElementById(id);
         if (!tbody) return;
         tbody.innerHTML = contributors.map((item) => {
+            const displayName = item.display_name || item.chinese_name || item.name || item.github_login || '';
             const name = item.github_url
-                ? `<a href="${item.github_url}" target="_blank" rel="noreferrer">${item.name}</a>`
-                : item.name;
+                ? `<a href="${item.github_url}" target="_blank" rel="noreferrer">${displayName}</a>`
+                : displayName;
+            const loginLine = item.github_login && item.github_login !== displayName
+                ? `<br><small>${item.github_login}</small>`
+                : '';
             const repos = Array.isArray(item.repos) ? item.repos.slice(0, 5).join(', ') : '';
             return `
                 <tr>
                     <td>${item.rank || ''}</td>
-                    <td>${name}<br><small>${item.github_login || ''}</small></td>
+                    <td>${name}${loginLine}</td>
                     <td>${fmt(item.commits)}</td>
                     <td>${fmt(item.changed_lines)}</td>
                     <td>${fmt(item.added)} / ${fmt(item.deleted)}</td>

--- a/data/core_contributors.json
+++ b/data/core_contributors.json
@@ -34,7 +34,10 @@
           "vllm-hust-website",
           "vllm-hust-workstation"
         ],
-        "key_contributions": "CI/CD, leaderboard, bugfix, distributed"
+        "key_contributions": "CI/CD, leaderboard, bugfix, distributed",
+        "display_name": "张书豪",
+        "chinese_name": "张书豪",
+        "english_name": "Shuhao Zhang"
       },
       {
         "rank": 2,
@@ -50,7 +53,10 @@
           "vllm-hust-benchmark",
           "vllm-hust-website"
         ],
-        "key_contributions": "CI/CD, leaderboard, benchmark, maintenance"
+        "key_contributions": "CI/CD, leaderboard, benchmark, maintenance",
+        "display_name": "王明琪",
+        "chinese_name": "王明琪",
+        "english_name": ""
       },
       {
         "rank": 3,
@@ -65,7 +71,10 @@
         "repos": [
           "vllm-hust-perf-analyzer"
         ],
-        "key_contributions": "distributed, docs"
+        "key_contributions": "distributed, docs",
+        "display_name": "田景远",
+        "chinese_name": "田景远",
+        "english_name": "Jingyuan Tian"
       },
       {
         "rank": 4,
@@ -80,7 +89,10 @@
         "repos": [
           "vllm-hust-website"
         ],
-        "key_contributions": "leaderboard"
+        "key_contributions": "leaderboard",
+        "display_name": "高西岭",
+        "chinese_name": "高西岭",
+        "english_name": "Xiling Gao"
       },
       {
         "rank": 5,
@@ -98,7 +110,10 @@
           "vllm-hust-dev-hub",
           "vllm-hust-website"
         ],
-        "key_contributions": "CI/CD, leaderboard, testing, website"
+        "key_contributions": "CI/CD, leaderboard, testing, website",
+        "display_name": "王胜",
+        "chinese_name": "王胜",
+        "english_name": "Sheng Wang"
       },
       {
         "rank": 6,
@@ -114,7 +129,10 @@
           "vllm-hust-website",
           "vllm-hust-workstation"
         ],
-        "key_contributions": "bugfix, distributed, leaderboard, maintenance"
+        "key_contributions": "bugfix, distributed, leaderboard, maintenance",
+        "display_name": "KimmoZAG",
+        "chinese_name": "",
+        "english_name": ""
       },
       {
         "rank": 7,
@@ -129,7 +147,10 @@
         "repos": [
           "vllm-hust-dev-hub"
         ],
-        "key_contributions": "Ascend, CI/CD, bugfix"
+        "key_contributions": "Ascend, CI/CD, bugfix",
+        "display_name": "iliujunn",
+        "chinese_name": "",
+        "english_name": "Lou Jun"
       },
       {
         "rank": 8,
@@ -144,7 +165,10 @@
         "repos": [
           "vllm-hust"
         ],
-        "key_contributions": "tooling"
+        "key_contributions": "tooling",
+        "display_name": "Remygred",
+        "chinese_name": "",
+        "english_name": ""
       },
       {
         "rank": 9,
@@ -159,7 +183,10 @@
         "repos": [
           "vllm-ascend-quant-hust"
         ],
-        "key_contributions": "misc"
+        "key_contributions": "misc",
+        "display_name": "王鸿坤",
+        "chinese_name": "王鸿坤",
+        "english_name": ""
       },
       {
         "rank": 10,
@@ -174,13 +201,16 @@
         "repos": [
           "vllm-hust-website"
         ],
-        "key_contributions": "leaderboard"
+        "key_contributions": "leaderboard",
+        "display_name": "朱鑫材",
+        "chinese_name": "朱鑫材",
+        "english_name": "Xincai Zhu"
       },
       {
         "rank": 11,
         "name": "MingXuan Kuang",
-        "github_login": null,
-        "github_url": null,
+        "github_login": "sad-and-bad1231",
+        "github_url": "https://github.com/sad-and-bad1231",
         "commits": 1,
         "changed_lines": 4,
         "added": 2,
@@ -189,7 +219,10 @@
         "repos": [
           ".github"
         ],
-        "key_contributions": "misc"
+        "key_contributions": "misc",
+        "display_name": "匡明轩",
+        "chinese_name": "匡明轩",
+        "english_name": "MingXuan Kuang"
       }
     ]
   },
@@ -214,7 +247,10 @@
           "vllm-ascend-hust",
           "vllm-hust"
         ],
-        "key_contributions": "CI/CD, Ascend, benchmark, bugfix"
+        "key_contributions": "CI/CD, Ascend, benchmark, bugfix",
+        "display_name": "张书豪",
+        "chinese_name": "张书豪",
+        "english_name": "Shuhao Zhang"
       },
       {
         "rank": 2,
@@ -229,7 +265,10 @@
         "repos": [
           "vllm-hust"
         ],
-        "key_contributions": "tooling"
+        "key_contributions": "tooling",
+        "display_name": "Remygred",
+        "chinese_name": "",
+        "english_name": ""
       },
       {
         "rank": 3,
@@ -244,7 +283,10 @@
         "repos": [
           "vllm-ascend-quant-hust"
         ],
-        "key_contributions": "misc"
+        "key_contributions": "misc",
+        "display_name": "王鸿坤",
+        "chinese_name": "王鸿坤",
+        "english_name": ""
       },
       {
         "rank": 4,
@@ -259,7 +301,10 @@
         "repos": [
           "vllm-hust"
         ],
-        "key_contributions": "kernel"
+        "key_contributions": "kernel",
+        "display_name": "王胜",
+        "chinese_name": "王胜",
+        "english_name": "Sheng Wang"
       }
     ]
   }

--- a/roadmap.md
+++ b/roadmap.md
@@ -116,8 +116,8 @@ Closed split PRs:
 - [Triton-Ascend #921](https://github.com/triton-lang/triton-ascend/pull/921) was closed because
   dropping test libraries without removing the corresponding registrations caused unresolved
   `mlir::test::*` symbols. The valid independent cleanup is #923.
-- [Triton-Ascend #924](https://github.com/triton-lang/triton-ascend/pull/924) was closed because
-  the NVWS target split caused duplicate `add_subdirectory` binary directories.
+- [Triton-Ascend #924](https://github.com/triton-lang/triton-ascend/pull/924) was closed because the
+  NVWS target split caused duplicate `add_subdirectory` binary directories.
 - [Triton-Ascend #925](https://github.com/triton-lang/triton-ascend/pull/925) was closed because
   gating Proton backend dependencies left the Python extension with an unresolved
   `init_triton_proton` symbol.

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -948,4 +948,6 @@ def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> No
     )
     assert "'./data/core_contributors.json'" in text
     assert "async function fetchPayload()" in text
+    assert "item.display_name || item.chinese_name || item.name || item.github_login || ''" in text
+    assert "item.github_login && item.github_login !== displayName" in text
     assert "console.warn('[contributors] source failed', source, err);" in text

--- a/tests/test_site_structure.py
+++ b/tests/test_site_structure.py
@@ -321,7 +321,14 @@ def test_shared_visual_styles_use_current_cache_key_and_non_negative_tracking() 
     assert ".cosmic-card::before" in css_text
     assert ".feature-card:hover" in css_text
 
-    for name in ("index.html", "leaderboard.html", "achievements.html", "contributors.html", "conferences.html", "courses.html"):
+    for name in (
+        "index.html",
+        "leaderboard.html",
+        "achievements.html",
+        "contributors.html",
+        "conferences.html",
+        "courses.html",
+    ):
         text = (root / name).read_text(encoding="utf-8")
         assert "assets/site.css?v=courses-20260708" in text
         assert "assets/site.js?v=courses-20260708" in text
@@ -948,6 +955,9 @@ def test_contributor_loader_prefers_org_profile_json_with_local_fallback() -> No
     )
     assert "'./data/core_contributors.json'" in text
     assert "async function fetchPayload()" in text
-    assert "item.display_name || item.chinese_name || item.name || item.github_login || ''" in text
+    assert (
+        "item.display_name || item.chinese_name || item.name || item.github_login || ''"
+        in text
+    )
     assert "item.github_login && item.github_login !== displayName" in text
     assert "console.warn('[contributors] source failed', source, err);" in text


### PR DESCRIPTION
## What changed
- updated `assets/contributors-page.js` to render `display_name` first, then fall back to `chinese_name`, `name`, and `github_login`
- kept GitHub profile links intact and only show the login line when it differs from the rendered display name
- refreshed `data/core_contributors.json` to match the new contributor metadata contract
- added a site-structure assertion covering the new contributors-page rendering logic

## Why
The contributors page should show Chinese names when that metadata is available, and preserve the previous display behavior as a fallback when it is not.

## Validation
- `pytest -p no:cacheprovider tests/test_site_structure.py -k contributor -q`
- local preview data check against `data/core_contributors.json`
